### PR TITLE
【feature】新規登録ページの名前フォームの実装 close #56

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,15 +1,15 @@
-<article class="flex justify-center items-center min-h-screen">
-  <div class="card shrink-0 w-full max-w-sm shadow-2xl bg-base-100 mt-2">
-    <h2 class="text-2xl font-bold mt-4 text-center"><%= t('.sign_up') %></h2>
+<article class="flex justify-center items-center pt-3">
+  <div class="card shrink-0 max-w-xs md:w-full md:max-w-sm shadow-2xl bg-base-100">
 
     <div class="card-body">
+      <h2 class="text-xl md:text-2xl font-bold md:mb-2 underline text-center"><%= t('.sign_up') %></h2>
       <!-- LINE認証 -->
-      <div class="form-control mt-1">
+      <div class="flex justify-center">
         <%= link_to "LINEで登録", "#", class: "btn btn-success" %>
       </div>
 
       <div class="border-b text-center">
-        <div class="leading-none px-2 inline-block text-sm text-gray-600 tracking-wide font-medium bg-white transform translate-y-1/2">
+        <div class="leading-none px-2 inline-block text-xs md:text-sm text-gray-600 tracking-wide font-medium bg-white transform translate-y-1/2">
           または
         </div>
       </div>
@@ -17,28 +17,31 @@
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
         
-        <div class="form-control mb-4">
-          <%= f.label :name %>
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered mt-2", placeholder: "名前を入力してください" %>
+        <div class="form-control my-1">
+          <%= f.label :name, class:"text-sm" %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-sm md:input-md input-bordered", placeholder: "名前を入力してね" %>
         </div>
 
-        <div class="form-control mb-4">
-          <%= f.label :email %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered mt-2", placeholder: "メールアドレスを入力してください" %>
+        <div class="form-control my-1">
+          <%= f.label :email, class:"text-sm" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-sm md:input-md input-bordered", placeholder: "メールアドレスを入力してね" %>
         </div>
 
-        <div class="form-control my-4">
-          <%= f.label :password %>
-          <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered mt-2", placeholder: "パスワードを入力してください" %>
+        <div class="form-control my-1">
+          <div class="flex">
+            <%= f.label :password, class:"text-sm" %>
+            <p class="text-sm"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></p>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input input-sm md:input-md input-bordered", placeholder: "パスワードを入力してね" %>
         </div>
 
-        <div class="form-control my-4">
-          <%= f.label :password_confirmation %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered mt-2", placeholder: "もう一度パスワードを入力してください" %>
+        <div class="form-control my-1">
+          <%= f.label :password_confirmation, class:"text-sm" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-sm md:input-md input-bordered", placeholder: "再度パスワードを入力してね" %>
         </div>
 
-        <div class="actions form-control mt-6">
-          <%= f.submit t('.sign_up'), class: "btn btn-accent" %>
+        <div class="flex justify-center mt-3">
+          <%= f.submit t('.sign_up'), class: "btn btn-sm md:btn-md btn-primary" %>
         </div>
       <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
   <div class="card shrink-0 max-w-xs md:w-full md:max-w-sm shadow-2xl bg-base-100">
 
     <div class="card-body">
-      <h2 class="text-xl md:text-2xl font-bold md:mb-2 underline text-center"><%= t('.sign_up') %></h2>
+      <h2 class="text-xl md:text-2xl font-bold mb-1 md:mb-2 underline text-center"><%= t('.sign_up') %></h2>
       <!-- LINE認証 -->
       <div class="flex justify-center">
         <%= link_to "LINEで登録", "#", class: "btn btn-success" %>
@@ -41,7 +41,7 @@
         </div>
 
         <div class="flex justify-center mt-3">
-          <%= f.submit t('.sign_up'), class: "btn btn-sm md:btn-md btn-primary" %>
+          <%= f.submit t('.sign_up'), class: "btn btn-sm md:btn-md btn-accent" %>
         </div>
       <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,25 +8,27 @@
         <%= link_to "LINEで登録", "#", class: "btn btn-success" %>
       </div>
 
-      <div class="my-4 border-b text-center">
+      <div class="border-b text-center">
         <div class="leading-none px-2 inline-block text-sm text-gray-600 tracking-wide font-medium bg-white transform translate-y-1/2">
-          または Eメールで登録する
+          または
         </div>
       </div>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
+        
+        <div class="form-control mb-4">
+          <%= f.label :name %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered mt-2", placeholder: "名前を入力してください" %>
+        </div>
 
         <div class="form-control mb-4">
           <%= f.label :email %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered mt-2", placeholder: "Eメールを入力してください" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered mt-2", placeholder: "メールアドレスを入力してください" %>
         </div>
 
         <div class="form-control my-4">
           <%= f.label :password %>
-          <% if @minimum_password_length %>
-          <p><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></p>
-          <% end %>
           <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered mt-2", placeholder: "パスワードを入力してください" %>
         </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
   
       <div class="my-4 border-b text-center">
         <div class="leading-none px-2 inline-block text-sm text-gray-600 tracking-wide font-medium bg-white transform translate-y-1/2">
-          または Eメールでログイン
+          または
         </div>
       </div>
   
@@ -19,7 +19,7 @@
   
         <div class="form-control mb-4">
           <%= f.label :email %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered mt-2", placeholder: "Eメールを入力してください" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered mt-2", placeholder: "メールアドレスを入力してください" %>
         </div>
   
         <div class="form-control my-4">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,5 +1,5 @@
-<header class="bg-base-100 shadow-sm md:flex md:justify-between md:p-2">
-  <div class="flex flex-col items-center space-x-3 pt-2 md:m-1">
+<header class="bg-base-100 shadow-sm md:flex md:justify-between md:p-1">
+  <div class="flex flex-col items-center space-x-3 pt-1 md:m-1">
     <%= link_to "Tripot Share", root_path, class:"text-xl md:text-3xl" %>
     <p class="text-xs mt-1">旅行計画共有サービス</p>
   </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,13 @@
 <footer class="absolute bottom-0 bg-secondary rounded shadow-inner w-full">
-  <div class="max-w-screen-xl mx-auto md:py-5">
-    <div class="md:flex md:items-center md:justify-between">
-      <div class="flex flex-col items-center space-x-3 m-4 mt-2">
-        <h2 class="text-3xl">
+  <div class="max-w-screen-xl mx-auto md:py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex flex-col items-center space-x-3 m-3">
+        <h2 class="text-2xl">
           Tripot Share
         </h2>
         <p class="text-xs mt-1">旅行計画共有サービス</p>
       </div>
-      <ul class="flex flex-col text-sm items-center m-6 font-medium gap-2">
+      <ul class="flex flex-col text-sm items-center pt-2 md-:pt-3 mr-3 font-medium gap-2">
         <li>
           <%= link_to "利用規約", "#" %>
         </li>
@@ -19,7 +19,7 @@
         </li>
       </ul>
     </div>
-    <hr class="border-gray-700 m-3 md:my-6" />
-    <span class="block text-sm text-center pb-3">© 2024 Tripot Share</span>
+    <hr class="border-gray-700 mx-3 my-2 md:my-4" />
+    <span class="block text-sm text-center pb-2 md:pb-0">© 2024 Tripot Share</span>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="bg-base-100 shadow-sm md:flex md:justify-between md:p-2">
-  <div class="flex flex-col items-center space-x-3 pt-2 md:m-1">
+<header class="bg-base-100 shadow-sm md:flex md:justify-between md:p-1">
+  <div class="flex flex-col items-center space-x-3 pt-1 md:m-1">
     <%= link_to "Tripot Share", root_path, class:"text-xl md:text-3xl" %>
     <p class="text-xs mt-1">旅行計画共有サービス</p>
   </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -16,7 +16,7 @@ ja:
         last_sign_in_at: 最終ログイン時刻
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻
-        password: パスワード（6字以上）
+        password: パスワード
         password_confirmation: パスワード（確認用）
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -9,20 +9,21 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        name: 名前
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻
-        password: パスワード
+        password: パスワード（6字以上）
         password_confirmation: パスワード（確認用）
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻
         reset_password_token: パスワードリセット用トークン
         sign_in_count: ログイン回数
-        unconfirmed_email: 未確認Eメール
+        unconfirmed_email: 未確認メールアドレス
         unlock_token: ロック解除用トークン
         updated_at: 更新日
     models:


### PR DESCRIPTION
### 概要
新規登録ページの名前フォームの実装

### 実装ページ
**PC画面**
<img width="1440" alt="4435b28ebc7d8864e1e8b55c53f82239" src="https://github.com/maru973/Tripot_Share/assets/148407473/9ffccd08-3d3e-4e79-9b20-af8f42dcd44a">

**スマホ画面**
<img width="409" alt="23c3938e2546ffb5e0672fe1060d5364" src="https://github.com/maru973/Tripot_Share/assets/148407473/91e3bbe0-1ebd-4a6f-aa82-22059532fa12">


### 内容
- [x] 名前フォームを追加
- [x] レスポンシブ対応  
- [x] Eメールの文言をメールアドレスに修正 


### 補足
LINEのボタンは別のissueで修正予定。
ヘッダーフッターも微妙に修正。