### PR TITLE
【fix】nameパラメーターの許可

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    # 新規登録時(sign_up時)にnameというキーのパラメーターの追加を許可
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end


### PR DESCRIPTION
### 概要
nameパラメーターの許可

### 実際のデータ
<img width="656" alt="df4a2334a8cffc392a1e07c2049fe1d7" src="https://github.com/maru973/Tripot_Share/assets/148407473/121a6b4b-eccb-45cc-ab0a-015aed7de3fe">


### 内容
- [x] コントローラーにnameの登録を許可するように設定