### PR TITLE
【fix】ログインページのデザイン修正 close #61

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,44 +1,43 @@
-<article class="flex justify-center items-center min-h-screen">
-  <div class="card shrink-0 w-full max-w-sm shadow-2xl bg-base-100 mt-2">
-    <h2 class="text-2xl font-bold mt-4 text-center"><%= t('.sign_in') %></h2>
-    
+<article class="flex justify-center items-center pt-3">
+  <div class="card shrink-0 max-w-xs md:w-full md:max-w-sm shadow-2xl bg-base-100">
+
     <div class="card-body">
-      <!-- LINEログイン -->
-      <div class="form-control mt-1">
+      <h2 class="text-xl md:text-2xl font-bold mb-1 md:mb-2 underline text-center"><%= t('.sign_in') %></h2>
+      <!-- LINE認証 -->
+      <div class="flex justify-center">
         <%= link_to "LINEでログイン", "#", class: "btn btn-success" %>
       </div>
-  
-      <div class="my-4 border-b text-center">
-        <div class="leading-none px-2 inline-block text-sm text-gray-600 tracking-wide font-medium bg-white transform translate-y-1/2">
+
+      <div class="border-b text-center">
+        <div class="leading-none px-2 inline-block text-xs md:text-sm text-gray-600 tracking-wide font-medium bg-white transform translate-y-1/2">
           または
         </div>
       </div>
-  
+
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
-  
-        <div class="form-control mb-4">
-          <%= f.label :email %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered mt-2", placeholder: "メールアドレスを入力してください" %>
+
+        <div class="form-control my-1">
+          <%= f.label :email, class:"text-sm" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-sm md:input-md input-bordered", placeholder: "メールアドレスを入力してね" %>
         </div>
-  
-        <div class="form-control my-4">
-          <%= f.label :password %>
-          <% if @minimum_password_length %>
-          <p><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></p>
-          <% end %>
-          <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered mt-2", placeholder: "パスワードを入力してください" %>
+
+        <div class="form-control my-1">
+          <div class="flex">
+            <%= f.label :password, class:"text-sm" %>
+          </div>
+          <%= f.password_field :password, autocomplete: "new-password", class: "input input-sm md:input-md input-bordered", placeholder: "パスワードを入力してね" %>
         </div>
-  
+
         <!--<% if devise_mapping.rememberable? %>
           <div class="field">
             <%= f.check_box :remember_me %>
             <%= f.label :remember_me %>
           </div>
         <% end %> -->
-  
-        <div class="actions form-control mt-6">
-          <%= f.submit t('.sign_in'), class: "btn btn-accent" %>
+
+        <div class="flex justify-center mt-3">
+          <%= f.submit t('.sign_in'), class: "btn btn-sm md:btn-md btn-accent" %>
         </div>
       <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name), class:"btn btn-link" %>
+  <%= link_to t(".sign_up"), new_registration_path(resource_name), class:"btn btn-link mx-3 md:mx-0" %>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>


### PR DESCRIPTION
### 概要
ログインページのデザイン修正

### 実装ページ
**PC画面**
<img width="1440" alt="a79240dedec6f50219fe93881403d3d2" src="https://github.com/maru973/Tripot_Share/assets/148407473/0245baeb-78a4-4e9b-8149-94576c60b8d9">

**スマホ画面**
<img width="320" alt="70b65b4d75d4f7394b758d7f62982a31" src="https://github.com/maru973/Tripot_Share/assets/148407473/c2aa7acb-4d67-4c9a-a2fe-adfcce1ef075">


### 内容
- [x] ログインページがスクロールせずに表示されるように調整
- [x] レスポンシブ対応  
