### PR TITLE
【feature】複数の地点にマーカーをつけてDBに情報を保存する close #18

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,3 +1,5 @@
 class PlansController < ApplicationController
-  def new; end
+  def new
+    @spot = Spot.new
+  end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -5,7 +5,7 @@ class SpotsController < ApplicationController
     @latlng = results.first.coordinates
     @spot.latitude = @latlng[0]
     @spot.longitude = @latlng[1]
-    @spot.address = results.first.address # ここで住所をセット
+    @spot.address = results.first.address
     @spot.save
   end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,6 +1,17 @@
 class SpotsController < ApplicationController
   def create
-    results = Geocoder.search(params[:name])
+    @spot = Spot.build(spot_params)
+    results = Geocoder.search(spot_params[:name])
     @latlng = results.first.coordinates
+    @spot.latitude = @latlng[0]
+    @spot.longitude = @latlng[1]
+    @spot.address = results.first.address # ここで住所をセット
+    @spot.save
+  end
+
+  private
+
+  def spot_params
+    params.require(:spot).permit(:name)
   end
 end

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -5,7 +5,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録フォーム -->
-  <%= render "spots/form" %>
+  <%= render "spots/form", spot: @spot %>
 
   <!-- 登録済みリスト -->
   <div role="tablist" class="tabs tabs-lifted tabs-xs md:tabs-lg mx-auto">

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -348,6 +348,9 @@
   // 他のファイルでも使用できるようにfunctionの外側で定義
   let map
 
+  // 配列にマーカーの情報を追加する
+  let markers = [];
+
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,5 +1,5 @@
 <div id="spot-form">
-  <%= form_with model: @spot, url: spots_path do |f|%>
+  <%= form_with model: spot, url: spots_path do |f|%>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
       <%= f.text_field :name, class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
       <%= f.submit "登録", class:"btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,11 +1,6 @@
 <script>
-  let spot = new google.maps.LatLng(
-   <%= @latlng[0] %>, //latitude
-   <%= @latlng[1] %>  //longitude
-  );
-
   let marker = new google.maps.Marker({
     map: map,
-    position: spot
+    position: {lat: latitude, lng: longitude}
   });
 </script>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,6 +1,12 @@
 <script>
-  let marker = new google.maps.Marker({
+  // let marker = new google.maps.Marker({
+  //   map: map,
+  //   position: {lat: <%=  @spot.latitude %>, lng: <%=  @spot.longitude %>}
+  // });
+
+  // マーカーを作成して配列に追加する
+  markers.push(new google.maps.Marker({
     map: map,
-    position: {lat: latitude, lng: longitude}
-  });
+    position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>}
+  }));
 </script>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,9 +1,4 @@
 <script>
-  // let marker = new google.maps.Marker({
-  //   map: map,
-  //   position: {lat: <%=  @spot.latitude %>, lng: <%=  @spot.longitude %>}
-  // });
-
   // マーカーを作成して配列に追加する
   markers.push(new google.maps.Marker({
     map: map,

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.append "map", partial: "marker", spot: @spot %>
+<%= turbo_stream.append "map", partial: "marker", spot: @spot.latitude, longitude: @spot.longitude %>
 <%= turbo_stream.replace "spot-form" do %>
   <%= render "form", spot: Spot.new %>
 <% end %>

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.append "map", partial: "marker", spot: @spot.latitude, longitude: @spot.longitude %>
+<%= turbo_stream.append "map", partial: "marker" %>
 <%= turbo_stream.replace "spot-form" do %>
   <%= render "form", spot: Spot.new %>
 <% end %>


### PR DESCRIPTION
### 概要
複数の地点にマーカーをつけてDBに情報を保存する

### 実装ページ
![e7ca954248db8061af7eb6dcd9d2ca04](https://github.com/maru973/Tripot_Share/assets/148407473/5df6e321-7684-40f6-a534-b6eb2c50abc2)


### テーブルの中身
<img width="688" alt="57bf08e6a5bddfd65055030bc42d063f" src="https://github.com/maru973/Tripot_Share/assets/148407473/b2b9ada0-e497-48ee-9a6e-12b1d47648fd">


### 内容
- [x] spotsテーブルにデータを保存する
- [x] 複数の地点が登録できるようにする
- [x] 複数の地点を登録した場合もテーブルにデータが保存できる   


### 補足
markerの変数を使用すると複数回の登録ができなかったため、今後のことも考え変数をなくすよりも配列に代入していく方法でマーカーをつけることにした。
（ルート提案を実装する上で、配列の方がいいのではと考えた。）