### PR TITLE
【feature】PlansテーブルとSpotsテーブルの紐付け close #74

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -6,13 +6,14 @@ class PlansController < ApplicationController
   def create
     @plan = Plan.build(plan_params)
     if @plan.save
-      redirect_to plans_new2_path
+      redirect_to plans_new2_path(@plan)
     else
       render :new
     end
   end
 
   def new2
+    @plan = Plan.find(params[:id])
     @spot = Spot.new
   end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,12 +1,15 @@
 class SpotsController < ApplicationController
   def create
-    @spot = Spot.build(spot_params)
-    results = Geocoder.search(spot_params[:name])
-    @latlng = results.first.coordinates
-    @spot.latitude = @latlng[0]
-    @spot.longitude = @latlng[1]
-    @spot.address = results.first.address
-    @spot.save
+    @spot = Spot.find_or_initialize_by(name: spot_params[:name])
+    if @spot.new_record?
+      results = Geocoder.search(spot_params[:name])
+      @latlng = results.first.coordinates
+      @spot.latitude = @latlng[0]
+      @spot.longitude = @latlng[1]
+      @spot.address = results.first.address
+      @spot.save
+    end
+    @planned_spot = PlannedSpot.create(plan_id: params[:plan_id], spot_id: @spot.id)
   end
 
   private

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,4 +1,6 @@
 class Plan < ApplicationRecord
+  has_many :planned_spot, dependent: :destroy
+
   validates :name, presence: true, length: { maximum: 255 }
 
   validate :start_date_before_end_date, if: -> { start_date.present? && end_date.present? } 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,5 +1,5 @@
 class Plan < ApplicationRecord
-  has_many :planned_spot, dependent: :destroy
+  has_many :planned_spots, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 255 }
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,5 +1,6 @@
 class Plan < ApplicationRecord
   has_many :planned_spots, dependent: :destroy
+  has_many :spots, through: :planned_spots
 
   validates :name, presence: true, length: { maximum: 255 }
 

--- a/app/models/planned_spot.rb
+++ b/app/models/planned_spot.rb
@@ -1,2 +1,4 @@
 class PlannedSpot < ApplicationRecord
+  belongs_to :plan
+  belongs_to :spot
 end

--- a/app/models/planned_spot.rb
+++ b/app/models/planned_spot.rb
@@ -1,0 +1,2 @@
+class PlannedSpot < ApplicationRecord
+end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,5 +1,5 @@
 class Spot < ApplicationRecord
-  has_many :planned_spot, dependent: :destroy
+  has_many :planned_spots, dependent: :destroy
 
   geocoded_by :address
   after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,5 +1,7 @@
 class Spot < ApplicationRecord
   has_many :planned_spots, dependent: :destroy
+  has_many :plans,through: :planned_spots
+
 
   geocoded_by :address
   after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,4 +1,6 @@
 class Spot < ApplicationRecord
+  has_many :planned_spot, dependent: :destroy
+
   geocoded_by :address
   after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
 end

--- a/app/views/plans/new2.html.erb
+++ b/app/views/plans/new2.html.erb
@@ -5,7 +5,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録フォーム -->
-  <%= render "spots/form", spot: @spot %>
+  <%= render "spots/form", spot: @spot, plan: @plan %>
 
   <!-- 登録済みリスト -->
   <div role="tablist" class="tabs tabs-lifted tabs-xs md:tabs-lg mx-auto">

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,5 +1,5 @@
 <div id="spot-form">
-  <%= form_with model: spot, url: spots_path do |f|%>
+  <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
       <%= f.text_field :name, class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
       <%= f.submit "登録", class:"btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.append "map", partial: "marker" %>
 <%= turbo_stream.replace "spot-form" do %>
-  <%= render "form", spot: Spot.new %>
+  <%= render "form", spot: Spot.new, plan: @planned_spot.plan %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get '/terms_of_service', to: 'staticpages#terms_of_service'
   get '/contact_us', to: 'staticpages#contact_us'
   
-  get '/plans/new2', to: 'plans#new2'
+  get '/plans/:id/new2', to: 'plans#new2', as: 'plans_new2'
 
   resources :plans do
     resources :spots, only: %i[create destroy], shallow: true

--- a/db/migrate/20240502050128_create_planned_spots.rb
+++ b/db/migrate/20240502050128_create_planned_spots.rb
@@ -1,0 +1,10 @@
+class CreatePlannedSpots < ActiveRecord::Migration[7.1]
+  def change
+    create_table :planned_spots do |t|
+      t.references :plan, null: false, foreign_key: true
+      t.references :spot, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_01_081322) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_02_050128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "planned_spots", force: :cascade do |t|
+    t.bigint "plan_id", null: false
+    t.bigint "spot_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id"], name: "index_planned_spots_on_plan_id"
+    t.index ["spot_id"], name: "index_planned_spots_on_spot_id"
+  end
 
   create_table "plans", force: :cascade do |t|
     t.string "name", null: false
@@ -46,4 +55,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_01_081322) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "planned_spots", "plans"
+  add_foreign_key "planned_spots", "spots"
 end


### PR DESCRIPTION
### 概要
PlansテーブルとSpotsテーブルの紐付け

### 実装ページ
![abc7ad6889bb95ac64293cd004037335](https://github.com/maru973/Tripot_Share/assets/148407473/511e04ea-f0de-4577-b1ff-a4e958141609)


### 実際のデータ
<img width="675" alt="cc814f4c3d8eead9f8fe11cb25955820" src="https://github.com/maru973/Tripot_Share/assets/148407473/5193e5b3-2e34-48c8-90d3-eb01c8db81d1">


### 内容
- [x] 中間テーブルplannedspotsテーブルの作成
- [x] 各モデルのアソシエーション設定
- [x] /plan/new2をplan_idを取得できるパスに変更
- [x] spotデータを保存したら中間テーブルにもデータを保存するように設定
- [x] spotsテーブルに既存データがあればそのデータを使い、なければ新規保存する    


### 補足
現在ページをリロードするとデータは保存されているが、マーカーが消えてしまう現象は今後のタスクで修正予定。