### PR TITLE
【bug】new2ページでスポット登録後リロードしても登録済みのマーカーが消えないように修正 close #76

### DIFF
--- a/app/views/plans/new2.html.erb
+++ b/app/views/plans/new2.html.erb
@@ -103,7 +103,17 @@
       disableDefaultUI: true,
       keyboardShortcuts: false
     });
+    
+    <% @spots.each do |spot| %>
+      (() => {
+        let marker = new google.maps.Marker({
+          map: map,
+          position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>}
+        });
+      })();
+    <% end %>
   } 
+
 </script>
 <!-- google mapのスクリプト -->
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly" defer></script>

--- a/app/views/plans/new2.html.erb
+++ b/app/views/plans/new2.html.erb
@@ -104,6 +104,7 @@
       keyboardShortcuts: false
     });
     
+    // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>
       (() => {
         let marker = new google.maps.Marker({


### PR DESCRIPTION
### 概要
new2ページでスポット登録後リロードしても登録ずみのマーカーが消えないように修正


### 実装ページ
![fa0598d3310cfcf6fc01cb8b0dd2bcea](https://github.com/maru973/Tripot_Share/assets/148407473/00e34325-b41e-4326-abea-f92a35116c7e)


### 内容
- [x] 地図の初期設定コードに登録済みのマーカーを表示するように設定
