### PR TITLE
【fix】planned_spotsテーブルにplan_idとspot_idが同じデータがすでに存在する場合は保存をしないように修正 close #81

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -9,7 +9,10 @@ class SpotsController < ApplicationController
       @spot.address = results.first.address
       @spot.save
     end
-    @planned_spot = PlannedSpot.create(plan_id: params[:plan_id], spot_id: @spot.id)
+    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
+    if @planned_spot.new_record?
+      @planned_spot.save
+    end
   end
 
   private

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,7 +1,9 @@
-<%= turbo_stream.append "map", partial: "marker" %>
+<% if @planned_spot.new_record? && @planned_spot.save %>
+  <%= turbo_stream.append "map", partial: "marker" %>
+  <%= turbo_stream.append "spot-table" do %>
+    <%= render "spot", spot: @spot %>
+  <% end %>
+<% end %>
 <%= turbo_stream.replace "spot-form" do %>
   <%= render "form", spot: Spot.new, plan: @planned_spot.plan %>
-<% end %>
-<%= turbo_stream.append "spot-table" do %>
-  <%= render "spot", spot: @spot %>
 <% end %>


### PR DESCRIPTION
### 概要
planned_spotsテーブルにplan_idとspot_idが同じデータがすでに存在する場合は保存をしないように修正


### 内容
- [x] spotsコントローラーのcreateアクションでPlanned_spotsテーブルにすでに同じplan_idとspot_idを持ったデータがないか条件分岐で確認
- [x] データがない場合のみ、情報を保存
- [x] 保存した場合のみ、create.turbo_stream.erbでマーカーをつけ、リストに反映させるように設定  