### PR TITLE
【feature】フラッシュメッセージの追加 close #51

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -9,7 +9,7 @@ class PlansController < ApplicationController
       redirect_to plans_new2_path(@plan), notice: "プランを作成しました"
     else
       flash.now[:alert] = "プランの作成に失敗しました"
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -6,8 +6,9 @@ class PlansController < ApplicationController
   def create
     @plan = Plan.build(plan_params)
     if @plan.save
-      redirect_to plans_new2_path(@plan)
+      redirect_to plans_new2_path(@plan), notice: "プランを作成しました"
     else
+      flash.now[:alert] = "プランの作成に失敗しました"
       render :new
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def flash_background_color(type)
+    case type.to_sym
+    when :notice then "bg-green-500"
+    when :alert  then "bg-red-500"
+    when :error  then "bg-yellow-500"
+    else "bg-gray-500"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,11 @@
 module ApplicationHelper
   def flash_background_color(type)
     case type.to_sym
-    when :notice then "bg-green-500"
-    when :alert  then "bg-red-500"
-    when :error  then "bg-yellow-500"
+    when :info  then "bg-info text-base-content"
+    when :notice then "bg-success text-base-content"
+    when :warning then "bg-warning text-base-content"
+    when :alert  then "bg-error"
+    when :error  then "bg-error text-base-content"
     else "bg-gray-500"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,10 @@
 module ApplicationHelper
-  def flash_background_color(type)
+  def flash_color(type)
     case type.to_sym
     when :info  then "bg-info text-base-content"
     when :notice then "bg-success text-base-content"
     when :warning then "bg-warning text-base-content"
-    when :alert  then "bg-error"
-    when :error  then "bg-error text-base-content"
+    when :alert  then "bg-error text-white"
     else "bg-gray-500"
     end
   end

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+  <div id="error_explanation" data-turbo-cache="false" class="bg-warning text-base-content">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,10 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <div class="pb-36 md:pb-48">
-    <%= yield %>
+      <%= yield %>
     </div>
-    <%= render "shared/footer" %>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -5,6 +5,7 @@
       <h2 class="text-lg md:text-2xl font-bold mb-1 md:mb-2 underline text-center">プラン作成</h2>
 
       <%= form_with model: @plan do |f|%>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="form-control my-3">
           <%= f.label :name, "プラン名" %>
           <%= f.text_field :name, autofocus: true, class: "input input-sm md:input-md input-bordered", placeholder: "例：卒業旅行 in 京都" %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="bg-warning text-base-content">
+    <ul class="mb-0">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>          
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div id="error_explanation" class="bg-warning text-base-content">
+  <div id="error_explanation" class="bg-warning text-base-content px-4 py-2 rounded-xl mb-4">
     <ul class="mb-0">
       <% object.errors.each do |error| %>
         <li><%= error.full_message %></li>          

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= flash_background_color(message_type) %> px-4 py-2 rounded-md text-white mb-4">
+  <div class="<%= flash_color(message_type) %> px-4 py-2 rounded-xl mb-4">
     <%= message %>
   </div>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module App
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -30,52 +30,52 @@ ja:
       user: ユーザー
   devise:
     confirmations:
-      confirmed: メールアドレスが確認できました。
+      confirmed: メールアドレスが確認できました
       new:
         resend_confirmation_instructions: アカウント確認メール再送
-      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます
     failure:
-      already_authenticated: すでにログインしています。
-      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
-      invalid: "%{authentication_keys}またはパスワードが違います。"
-      last_attempt: もう一回誤るとアカウントがロックされます。
-      locked: アカウントはロックされています。
-      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
-      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
-      unauthenticated: ログインもしくはアカウント登録してください。
-      unconfirmed: メールアドレスの本人確認が必要です。
+      already_authenticated: すでにログインしています
+      inactive: アカウントが有効化されていません メールに記載された手順にしたがって、アカウントを有効化してください
+      invalid: "%{authentication_keys}またはパスワードが違います"
+      last_attempt: もう一回誤るとアカウントがロックされます
+      locked: アカウントはロックされています
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います"
+      timeout: セッションがタイムアウトしました もう一度ログインしてください
+      unauthenticated: ログインもしくはアカウント登録してください
+      unconfirmed: メールアドレスの本人確認が必要です
     mailer:
       confirmation_instructions:
         action: メールアドレスの確認
         greeting: "%{recipient}様"
-        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください
         subject: メールアドレス確認メール
       email_changed:
-        greeting: こんにちは、%{recipient}様。
-        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
-        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        greeting: こんにちは、%{recipient}様
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています
         subject: メール変更完了
       password_change:
         greeting: "%{recipient}様"
-        message: パスワードが再設定されました。
+        message: パスワードが再設定されました
         subject: パスワードの変更について
       reset_password_instructions:
         action: パスワード変更
         greeting: "%{recipient}様"
-        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
-        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
-        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています 下のリンクからパスワードの再設定ができます
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません
         subject: パスワードの再設定について
       unlock_instructions:
         action: アカウントのロック解除
         greeting: "%{recipient}様"
-        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
-        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています
         subject: アカウントのロック解除について
     omniauth_callbacks:
-      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
-      success: "%{kind} アカウントによる認証に成功しました。"
+      failure: "%{kind} アカウントによる認証に失敗しました 理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました"
     passwords:
       edit:
         change_my_password: パスワードを変更する
@@ -85,13 +85,13 @@ ja:
       new:
         forgot_your_password: パスワードを忘れましたか？
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
-      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
-      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
-      updated: パスワードが正しく変更されました。
-      updated_not_active: パスワードが正しく変更されました。
+      no_token: このページにはアクセスできません パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます
+      updated: パスワードが正しく変更されました
+      updated_not_active: パスワードが正しく変更されました
     registrations:
-      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      destroyed: アカウントを削除しました またのご利用をお待ちしております
       edit:
         are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
@@ -103,19 +103,19 @@ ja:
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
         sign_up: アカウント登録
-      signed_up: アカウント登録が完了しました。
-      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
-      signed_up_but_locked: アカウントがロックされているためログインできません。
-      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
-      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
-      updated: アカウント情報を変更しました。
-      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+      signed_up: アカウント登録が完了しました
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください
+      signed_up_but_locked: アカウントがロックされているためログインできません
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました メール内のリンクからアカウントを有効化させてください
+      update_needs_confirmation: アカウント情報を変更しました 変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください
+      updated: アカウント情報を変更しました
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください
     sessions:
-      already_signed_out: 既にログアウト済みです。
+      already_signed_out: 既にログアウト済みです
       new:
         sign_in: ログイン
-      signed_in: ログインしました。
-      signed_out: ログアウトしました。
+      signed_in: ログインしました
+      signed_out: ログアウトしました
     shared:
       links:
         back: 戻る
@@ -129,16 +129,16 @@ ja:
     unlocks:
       new:
         resend_unlock_instructions: アカウントのロック解除方法を再送する
-      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
-      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
-      unlocked: アカウントをロック解除しました。
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します
+      unlocked: アカウントをロック解除しました
   errors:
     messages:
-      already_confirmed: は既に登録済みです。ログインしてください。
-      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
-      expired: の有効期限が切れました。新しくリクエストしてください。
-      not_found: は見つかりませんでした。
-      not_locked: はロックされていません。
+      already_confirmed: は既に登録済みです ログインしてください
+      confirmation_period_expired: の期限が切れました %{period} までに確認する必要があります 新しくリクエストしてください
+      expired: の有効期限が切れました新しくリクエストしてください
+      not_found: は見つかりませんでした
+      not_locked: はロックされていません
       not_saved:
-        one: エラーが発生したため %{resource} は保存されませんでした。
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+        one: エラーが発生したため %{resource} は保存されませんでした
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした"


### PR DESCRIPTION
### 概要
フラッシュメッセージの追加

### 実装ページ
<img width="1434" alt="df53e4261f8661b199da38eb0c767883" src="https://github.com/maru973/Tripot_Share/assets/148407473/1b201c63-ceeb-4a95-8f65-2d62d7055eed">


### 内容
- [x] フラッシュメッセージのパーシャルファイル作成
- [x] devise以外のエラーメッセージのパーシャルファイル作成
- [x] deviseのエラーメッセージデザイン修正

### 補足
時間を日本時間に設定。
deviseの国際化していた文字列の読点を全て削除。