### PR TITLE
【feature】ページネーションのデザイン実装 close #96

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+<div class="first">
+  <%= link_to_unless current_page.first?, "««", url, {remote: remote, class: "join-item btn btn-secondary" } %>
+</div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="first">
-  <%= link_to_unless current_page.first?, "««", url, {remote: remote, class: "join-item btn btn-secondary" } %>
+  <%= link_to_unless current_page.first?, "««", url, {remote: remote, class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe, class: "join-item btn btn-disabled" %></span>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe, class: "join-item btn-sm md:btn-md btn btn-disabled" %></span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe, class: "join-item btn-sm md:btn-md btn btn-disabled" %></span>
+<div class="page gap">
+  <%= t('views.pagination.truncate').html_safe, class: "join-item btn-sm md:btn-md btn btn-disabled" %>
+</div>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe, class: "join-item btn btn-disabled" %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="last">
-  <%= link_to_unless current_page.last?, "»»", url, {remote: remote, class: "join-item btn btn-secondary" } %>
+  <%= link_to_unless current_page.last?, "»»", url, {remote: remote, class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<div class="last">
+  <%= link_to_unless current_page.last?, "»»", url, {remote: remote, class: "join-item btn btn-secondary" } %>
+</div>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="next">
-  <%= link_to_unless current_page.last?, "»", url, {remote: remote, rel: 'next', class: "join-item btn btn-secondary" } %>
+  <%= link_to_unless current_page.last?, "»", url, {remote: remote, rel: 'next', class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
-</span>
+<div class="next">
+  <%= link_to_unless current_page.last?, "»", url, {remote: remote, rel: 'next', class: "join-item btn btn-secondary" } %>
+</div>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -10,10 +10,10 @@
 
 <% if page.current? %>
   <div class="page current">
-    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-accent" } %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm md:btn-md btn-accent" } %>
   </div>
 <% else %>
   <div class="page">
-    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-secondary" } %>
+    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
   </div>
 <% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -10,10 +10,10 @@
 
 <% if page.current? %>
   <div class="page current">
-    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm btn-accent" } %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-accent" } %>
   </div>
 <% else %>
   <div class="page">
-    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm btn-info" } %>
+    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-secondary" } %>
   </div>
 <% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,19 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+
+<% if page.current? %>
+  <div class="page current">
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm btn-accent" } %>
+  </div>
+<% else %>
+  <div class="page">
+    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm btn-info" } %>
+  </div>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,27 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<div class="join flex">
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>
+</div>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,22 +6,22 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
-<div class="join flex">
-<%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
-    <% each_page do |page| -%>
-      <% if page.display_tag? -%>
-        <%= page_tag page %>
-      <% elsif !page.was_truncated? -%>
-        <%= gap_tag %>
+<div class="flex justify-center my-7">
+  <%= paginator.render do -%>
+    <nav class="pagination join" role="navigation" aria-label="pager">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
       <% end -%>
-    <% end -%>
-    <% unless current_page.out_of_range? %>
-      <%= next_page_tag unless current_page.last? %>
-      <%= last_page_tag unless current_page.last? %>
-    <% end %>
-  </nav>
-<% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+        <%= last_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  <% end -%>
 </div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="prev">
-  <%= link_to_unless current_page.first?, "«".html_safe, url, {remote: remote, rel: 'prev', class: "join-item btn btn-secondary" } %>
+  <%= link_to_unless current_page.first?, "«".html_safe, url, {remote: remote, rel: 'prev', class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
-</span>
+<div class="prev">
+  <%= link_to_unless current_page.first?, "«".html_safe, url, {remote: remote, rel: 'prev', class: "join-item btn btn-secondary" } %>
+</div>

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -21,7 +21,7 @@
       <%= link_to "詳細 →", plan_path(plan), class:"link" %>
     </div>
   </div>
-  <div class="card-actions justify-end mb-3 mr-3 group-hover:opacity-100 md:opacity-0 transform transition-all delay-200 duration-300">
+  <div class="card-actions justify-end mb-4 mr-7 group-hover:opacity-100 md:opacity-0 transform transition-all delay-200 duration-300">
     <%= link_to "詳細 →", plan_path(plan), class:"link" %>
   </div>
 </div>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,7 +1,9 @@
-<article class="grid justify-center items-center">
-  <h2 class="text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center">プラン一覧</h2>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-10 mt-3">
-    <%= render @plans %>
-    <%= paginate @plans %>
+<article>
+  <div class="grid justify-center items-center">
+    <h2 class="text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center">プラン一覧</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-10 mt-3">
+      <%= render @plans %>
+    </div>
   </div>
+  <%= paginate @plans %>
 </article>


### PR DESCRIPTION
### 概要
ページネーションのデザイン実装

### 実装ページ
PC画面
![46b56d71c725631daf622214608d3b51](https://github.com/maru973/Tripot_Share/assets/148407473/651566bf-86aa-48ae-9314-837a618eaacf)

スマホ画面
<img width="253" alt="fa260538c796c2e13d28aa93ccafed7e" src="https://github.com/maru973/Tripot_Share/assets/148407473/18772442-20d8-40aa-add4-a8a10f79a0d5">


### 内容
- [x] ページネーションのビューを追加
- [x] スマホ画面でページネーションが小さくなるように  


### 補足
t('views.pagination.truncate')の部分は今後のタスクで国際化をするときに実装予定。