### PR TITLE
【bug】ヘッダーがプルダウンがbodyに隠れてしまうのを修正 close #94

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,21 +8,34 @@
       <li class="hidden md:block link link-hover"><%= link_to "みんなのプランをみる", "#" %></li>
       <li class="hidden md:block link link-hover"><%= link_to "旅行プランをつくる", "#" %></li>
       <li>
-        <details>
-          <summary>
-            <p class="hidden md:block">マイメニュー</p>
-            <p class="md:hidden">　　メニュー</p>
-          </summary>
-          <ul class="bg-base-100 rounded-t-none w-38">
+        <div class="dropdown dropdown-bottom dropdown-end">
+          <div tabindex="0" role="button">
+            <div class="hidden md:block">
+              <div class="flex">
+                マイメニュー
+                <span class="material-symbols-outlined">
+                  expand_more
+                </span>
+              </div>
+            </div>
+
+            <!-- スマホ画面ではハンバーガーメニュー -->
+            <div class="md:hidden">
+              <span class="material-symbols-outlined">
+                menu
+              </span>
+            </div>
+
+          </div>
+          <ul tabindex="0" class="border dropdown-content z-[1] menu mt-2 md:mt-4 shadow bg-base-100 rounded-box w-40 md:w-52">
             <li class="md:hidden"><%= link_to "プラン計画", "#" %></li>
             <li><%= link_to "マイプラン", "#" %></li>
             <li class="md:hidden"><%= link_to "皆のプラン", "#" %></li>
             <li><%= link_to "マイページ", "#" %></li>
             <li><%= link_to "ログアウト", destroy_user_session_path, data: {turbo_method: :delete} %></li>
           </ul>
-        </details>
+        </div>
       </li>
     </ul>
   </div>
-
 </header>


### PR DESCRIPTION
### 概要
ヘッダーがbodyに隠れてしまうのを修正

### 実装ページ
PC画面
<img width="328" alt="2e9eb096a0c8c322b3fff811604a14d1" src="https://github.com/maru973/Tripot_Share/assets/148407473/b167d8d5-07f2-4425-948c-aa0a62078b94">

スマホ画面
<img width="398" alt="1ab3937d5083750503f60a19d23d4f02" src="https://github.com/maru973/Tripot_Share/assets/148407473/015b1c0f-9dfe-4e33-84ef-2af65cc1362e">



### 内容
- [x] ヘッダーのブルダウンがbodyよりも上に来る 
- [x] スマホ画面でハンバーガーメニューが表示される 
