### PR TITLE
【feature】UserとPlanの紐付け close #100

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -24,7 +24,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in(:user, @profile)
   
       flash[:notice] = "ログインしました"
-      redirect_to root_path
+      redirect_to plans_path
 
     else
       flash[:alert] = '認証に失敗しました'

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -32,6 +32,6 @@ class PlansController < ApplicationController
   private
 
   def plan_params
-    params.require(:plan).permit(:name, :start_date, :end_date, :user_id)
+    params.require(:plan).permit(:name, :start_date, :end_date)
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,6 +1,6 @@
 class PlansController < ApplicationController
   def index
-    @plans = Plan.all.page(params[:page])
+    @plans = current_user.plans.page(params[:page])
   end
 
   def new

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -8,7 +8,8 @@ class PlansController < ApplicationController
   end
 
   def create
-    @plan = Plan.build(plan_params)
+    @plan = current_user.plans.build(plan_params)
+    @plan.owner_id = current_user.id
     if @plan.save
       redirect_to new_spots_path(@plan), notice: "プランを作成しました"
     else
@@ -31,6 +32,6 @@ class PlansController < ApplicationController
   private
 
   def plan_params
-    params.require(:plan).permit(:name, :start_date, :end_date)
+    params.require(:plan).permit(:name, :start_date, :end_date, :user_id)
   end
 end

--- a/app/controllers/staticpages_controller.rb
+++ b/app/controllers/staticpages_controller.rb
@@ -1,4 +1,6 @@
 class StaticpagesController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def top; end
 
   def privacy_policy; end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,6 +1,7 @@
 class Plan < ApplicationRecord
   has_many :planned_spots, dependent: :destroy
   has_many :spots, through: :planned_spots
+  belongs_to :owner, class_name: 'User', foreign_key: 'owner_id'
 
   validates :name, presence: true, length: { maximum: 255 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :plans, foreign_key: 'owner_id'
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,9 +1,13 @@
 <article>
   <div class="grid justify-center items-center">
     <h2 class="text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center">プラン一覧</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-10 mt-3">
-      <%= render @plans %>
-    </div>
+    <% if @plans.present? %>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-10 mt-3">
+        <%= render @plans %>
+      </div>
+    <% else %>
+      <p>プランはありません</p>
+    <% end %>
   </div>
   <%= paginate @plans %>
 </article>

--- a/db/migrate/20240508075523_add_owner_id_to_plans.rb
+++ b/db/migrate/20240508075523_add_owner_id_to_plans.rb
@@ -1,0 +1,6 @@
+class AddOwnerIdToPlans < ActiveRecord::Migration[7.1]
+  def change
+    add_column :plans, :owner_id, :integer, null: false
+    add_foreign_key :plans, :users, column: :owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_02_050128) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_08_075523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_050128) do
     t.date "end_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "owner_id", null: false
   end
 
   create_table "spots", force: :cascade do |t|
@@ -57,4 +58,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_050128) do
 
   add_foreign_key "planned_spots", "plans"
   add_foreign_key "planned_spots", "spots"
+  add_foreign_key "plans", "users", column: "owner_id"
 end


### PR DESCRIPTION
### 概要
UserとPlanの紐付け

### 実装ページ
<img width="674" alt="0f46ae9c6196e11b7293580994f08839" src="https://github.com/maru973/Tripot_Share/assets/148407473/679eaa45-4bd1-42b2-8046-cb639c1906f2">


### 内容
- [x] Plansテーブルにowner_idのカラムを追加
- [x] current_user.idがPlansテーブルのowner_idとして保存されるように設定
- [x] staticpages以外ログインしないと表示できないように設定
- [x] 一覧ページで自分のプランのみ表示するように設定    


### 補足
一覧ページでは暫定的に自分のプランのみ表示しているが、今後の実装でマイページに移行する？かも。