### PR TITLE
【bug】turboがリロードしないと反映しない現象を解消 close #88

### DIFF
--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<% if @planned_spot.new_record? && @planned_spot.save %>
+<% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
   <%= turbo_stream.append "spot-table" do %>
     <%= render "spot", spot: @spot %>


### PR DESCRIPTION
### 概要
turboがリロードしないと反映しない現象を解消

### 補足
リロードしない問題は解決したが、条件分岐をしたappendが既存データの場合でも反映してしまう問題は未解消。