### PR TITLE
【feature】当日よりも前の日付を選択できないようにバリデーションを設定 close #93

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -5,13 +5,24 @@ class Plan < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 255 }
 
-  validate :start_date_before_end_date, if: -> { start_date.present? && end_date.present? } 
+  validate :dates_check
 
   private
 
-  def start_date_before_end_date
-    if start_date >= end_date
-      errors.add(:start_date, '旅行終了日より前の日付に設定してください。')
+  def dates_check
+    if start_date.present? && end_date.present?
+      if start_date > end_date
+        errors.add(:start_date, '旅行終了日より前の日付に設定してください')
+        return # ここで返却、以下の処理をスキップする。
+      end
+    end
+
+    if start_date.present? && start_date < Date.today
+      errors.add(:start_date, '今日以降の日付に設定してください')
+    end
+
+    if end_date.present? && end_date < Date.today
+      errors.add(:end_date, '今日以降の日付に設定してください')
     end
   end
 end


### PR DESCRIPTION
### 概要
当日よりも前の日付を選択できないようにバリデーションを設定

### 実装ページ
<img width="1432" alt="28aa2e6ff5b50a4399a5ab7f073d6ea7" src="https://github.com/maru973/Tripot_Share/assets/148407473/ac61e295-639b-4413-83e8-29c9201182ba">



### 内容
- [x] start_dateもend_dateも当日以前の日付を選択できないように設定
- [x] start_date > end_dateに変更し、 同じ日付でも登録できるように設定 
