### PR TITLE
【feature】メールによる招待機能の追加 close #106

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'letter_opener_web'
 end
 
 gem 'cssbundling-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -71,5 +71,6 @@ gem 'dotenv-rails'
 gem 'geocoder'
 gem 'kaminari'
 gem 'rails-i18n'
+gem 'devise_invitable'
 
 gem "dockerfile-rails", ">= 1.6", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
@@ -82,6 +84,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    childprocess (5.0.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -141,6 +144,16 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -197,6 +210,7 @@ GEM
     pg (1.5.6)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -251,6 +265,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.2.6)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -304,6 +319,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  letter_opener_web
   omniauth-line
   omniauth-rails_csrf_protection
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.12.0)
       devise (>= 4.9.0)
+    devise_invitable (2.0.9)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     dockerfile-rails (1.6.8)
       rails (>= 3.0.0)
     dotenv (3.1.0)
@@ -313,6 +316,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  devise_invitable
   dockerfile-rails (>= 1.6)
   dotenv-rails
   geocoder

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[line]
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { minimum: 2 }
 
   def set_values(omniauth)
     return if provider.to_s != omniauth["provider"].to_s || uid != omniauth["uid"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[line]
 

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,22 @@
+<h2><%= t "devise.invitations.edit.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :invitation_token, readonly: true %>
+
+  <% if f.object.class.require_password_on_accepting %>
+    <div class="field">
+      <%= f.label :password %><br />
+      <%= f.password_field :password %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.edit.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,16 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <% resource.class.invite_key_fields.each do |field| -%>
+    <div class="field">
+      <%= f.label field %><br />
+      <%= f.text_field field %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.new.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", name: @user.name) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,4 +75,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.hosts << '.ngrok-free.app'
+
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.action_mailer.default_url_options = { protocol: 'https', host: 'tripot-share.fly.dev' }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -134,6 +134,55 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -1,0 +1,31 @@
+ja:
+  devise:
+    failure:
+      invited: 'アカウントを作成するには、保留中の招待を承認してください。'
+    invitations:
+      send_instructions: '招待メールが%{email}に送信されました。'
+      invitation_token_invalid: '招待コードが不正です。'
+      updated: 'パスワードが設定されました。お使いのアカウントでログインできます。'
+      updated_not_active: 'パスワードが設定されました。'
+      no_invitations_remaining: 'これ以上招待できません。'
+      invitation_removed: '招待を取り消しました。'
+      new:
+        header: '招待する'
+        submit_button: '招待メールを送る'
+      edit:
+        header: 'パスワードを設定する'
+        submit_button: 'パスワードを設定する'
+    mailer:
+      invitation_instructions:
+        subject: '招待を承認するには'
+        hello: 'こんにちは、%{email}さん'
+        someone_invited_you: '%{url}に招待されました。以下のリンクから承認できます。'
+        accept: '招待を承認する'
+        accept_until: 'この招待は%{due_date}まで有効です。'
+        ignore: '招待を承認しない場合は、このメールを無視してください。<br />あなたのアカウントは上記のリンク先にアクセスしパスワードを設定するまでは作成されません。'
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: '%Y年%m月%d日%H時%M分'

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -17,12 +17,12 @@ ja:
         submit_button: 'パスワードを設定する'
     mailer:
       invitation_instructions:
-        subject: '招待を承認するには'
+        subject: '旅行メンバーに招待されました'
         hello: 'こんにちは、%{email}さん'
         someone_invited_you: '%{url}に招待されました。以下のリンクから承認できます。'
-        accept: '招待を承認する'
+        accept: 'このプランに参加する'
         accept_until: 'この招待は%{due_date}まで有効です。'
-        ignore: '招待を承認しない場合は、このメールを無視してください。<br />あなたのアカウントは上記のリンク先にアクセスしパスワードを設定するまでは作成されません。'
+        ignore: '身に覚えがない場合は、このメールを無視してください。'
   time:
     formats:
       devise:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   devise_for :users, controllers: {
     omniauth_callbacks: "omniauth_callbacks"
   }

--- a/db/migrate/20240417024712_add_column_to_users.rb
+++ b/db/migrate/20240417024712_add_column_to_users.rb
@@ -2,6 +2,6 @@ class AddColumnToUsers < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :provider, :string
     add_column :users, :uid, :string
-    add_column :users, :name, :string, null:false
+    add_column :users, :name, :string, null:false, default: ""
   end
 end

--- a/db/migrate/20240509014941_devise_invitable_add_to_users.rb
+++ b/db/migrate/20240509014941_devise_invitable_add_to_users.rb
@@ -1,0 +1,22 @@
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[7.1]
+  def up
+    change_table :users do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitation_token, unique: true # for invitable
+      t.index      :invited_by_id
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_08_075523) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_014941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,7 +52,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_08_075523) do
     t.string "provider"
     t.string "uid"
     t.string "name", null: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.integer "invitations_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,9 +49,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_014941) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "provider"
-    t.string "uid"
-    t.string "name", null: false
     t.string "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
@@ -60,6 +57,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_014941) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.string "provider"
+    t.string "uid"
+    t.string "name", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"


### PR DESCRIPTION
### 概要
メールによる招待機能の追加

### 実装ページ
<img width="542" alt="1b7fcd2dddcd448c835fe0d3ed70af78" src="https://github.com/maru973/Tripot_Share/assets/148407473/67163ebe-71de-4fd2-814a-aefeab16a41a">



### 内容
- [x] gem letter_openerの導入
- [x] 開発環境のみletter_openerを使用できるよう設定
- [x]  gem 'devise_invitable'の導入
- [x] usersテーブルのnameカラムにデフォルト値を追加
- [x] userモデルにnameに2文字以上のバリデーションを追加 

### 補足
本番環境でのメール設定はこれ以降に行う。