### PR TITLE
【feature】招待リンクを開いて会員登録すると自分のplanとして保存される close #107

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # 新規登録時(sign_up時)にnameというキーのパラメーターの追加を許可
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :plan_id])
+    devise_parameter_sanitizer.permit(:invite) { |u| u.permit(:email, :name, :plan_id) }
+    devise_parameter_sanitizer.permit(:accept_invitation) { |u| u.permit(:password, :password_confirmation, :invitation_token, :name, :plan_id) }
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -11,6 +11,7 @@ class PlansController < ApplicationController
     @plan = current_user.plans.build(plan_params)
     @plan.owner_id = current_user.id
     if @plan.save
+      @plan.users << current_user
       redirect_to new_spots_path(@plan), notice: t('defaults.flash_message.created', item: Plan.model_name.human)
     else
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Plan.model_name.human)

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -1,39 +1,39 @@
 class Users::InvitationsController < Devise::InvitationsController
-  # def create
-  #     super
-  #     @member = Member.new
-  #     #Memberテーブルに招待したいユーザーのidを入れる。
-  #     @member.user_id = User.find_by(email: params[:user][:email]).id
-  #     @member.list_id = params[:user][:list_id]
-  #     @member.save
-  # end
-
   def create
-    user_email = params[:user][:email]
-    plan_id = params[:user][:plan_id]
-    user_id = User.find_by(email: user_email.downcase).id
-    if User.find_by(email: user_email.downcase).present? #　既存ユーザーの処理
-      user = User.find(user_id)
-      if user.plan_ids.include?(plan_id.to_i)
-        redirect_to root_path, alert: "このリストは登録済みです。"
-      else
-      user.invite!
+      super
       @member = Member.new
-      #Memberテーブルに招待したいユーザーのidとリストのidを入れる。
-      @member.user_id = user_id
-      @member.plan_id = plan_id
+      #Memberテーブルに招待したいユーザーのidを入れる。
+      @member.user_id = User.find_by(email: params[:user][:email]).id
+      @member.plan_id = params[:user][:plan_id]
       @member.save
-      redirect_to root_path, notice: t('.send_instructions')
-      end
-    elsif User.invite!(email: user_email, plan_id: plan_id) # 新規ユーザーの処理
-      redirect_to plans_path(current_user), notice: t('.send_instructions')
-      @member = Member.new
-      @member.user_id = user_id
-      @member.plan_id = plan_id
-      @member.save
-    else
-      flash[:notice] = t('.failure')
-      render 'new', locals: { plan: plan_id }
-    end
   end
+
+  # def create
+  #   user_email = params[:user][:email]
+  #   plan_id = params[:user][:plan_id]
+  #   user_id = User.find_by(email: user_email.downcase).id
+  #   if User.find_by(email: user_email.downcase).present? #　既存ユーザーの処理
+  #     user = User.find(user_id)
+  #     if user.plan_ids.include?(plan_id.to_i)
+  #       redirect_to root_path, alert: "このリストは登録済みです。"
+  #     else
+  #     user.invite!
+  #     @member = Member.new
+  #     #Memberテーブルに招待したいユーザーのidとリストのidを入れる。
+  #     @member.user_id = user_id
+  #     @member.plan_id = plan_id
+  #     @member.save
+  #     redirect_to root_path, notice: t('.send_instructions')
+  #     end
+  #   elsif User.invite!(email: user_email, plan_id: plan_id) # 新規ユーザーの処理
+  #     redirect_to plans_path(current_user), notice: t('.send_instructions')
+  #     @member = Member.new
+  #     @member.user_id = user_id
+  #     @member.plan_id = plan_id
+  #     @member.save
+  #   else
+  #     flash[:notice] = t('.failure')
+  #     render 'new', locals: { plan: plan_id }
+  #   end
+  # end
 end

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -1,39 +1,52 @@
 class Users::InvitationsController < Devise::InvitationsController
   def create
-      super
-      @member = Member.new
-      #Memberテーブルに招待したいユーザーのidを入れる。
-      @member.user_id = User.find_by(email: params[:user][:email]).id
-      @member.plan_id = params[:user][:plan_id]
-      @member.save
+    @user =User.new
+    user_email = params[:user][:email]
+    plan_id = params[:user][:plan_id]
+    if User.find_by(email: user_email.downcase).present? #　既存ユーザーの処理
+      user_id = User.find_by(email: user_email.downcase).id
+      user = User.find(user_id)
+      if user.plan_ids.include?(plan_id.to_i)
+        redirect_to root_path, alert: "このリストは登録済みです。"
+      else
+        user.invite!(current_user)
+        #Memberテーブルに招待したいユーザーのidとリストのidを入れる。
+        user.invited_plan_id = plan_id
+        user.save
+        redirect_to root_path, notice: t('devise.invitations.send_instructions', email: user_email)
+      end
+    elsif User.invite!(email: user_email, invited_plan_id: plan_id).valid? # 新規ユーザーの処理
+      redirect_to plans_path(current_user), notice: t('devise.invitations.send_instructions', email: user_email)
+    else
+      flash[:notice] = t('devise.invitations.failure')
+      render 'new', locals: { plan: plan_id }
+    end
   end
 
-  # def create
-  #   user_email = params[:user][:email]
-  #   plan_id = params[:user][:plan_id]
-  #   user_id = User.find_by(email: user_email.downcase).id
-  #   if User.find_by(email: user_email.downcase).present? #　既存ユーザーの処理
-  #     user = User.find(user_id)
-  #     if user.plan_ids.include?(plan_id.to_i)
-  #       redirect_to root_path, alert: "このリストは登録済みです。"
-  #     else
-  #     user.invite!
-  #     @member = Member.new
-  #     #Memberテーブルに招待したいユーザーのidとリストのidを入れる。
-  #     @member.user_id = user_id
-  #     @member.plan_id = plan_id
-  #     @member.save
-  #     redirect_to root_path, notice: t('.send_instructions')
-  #     end
-  #   elsif User.invite!(email: user_email, plan_id: plan_id) # 新規ユーザーの処理
-  #     redirect_to plans_path(current_user), notice: t('.send_instructions')
-  #     @member = Member.new
-  #     @member.user_id = user_id
-  #     @member.plan_id = plan_id
-  #     @member.save
-  #   else
-  #     flash[:notice] = t('.failure')
-  #     render 'new', locals: { plan: plan_id }
-  #   end
-  # end
+  def update
+    raw_invitation_token = update_resource_params[:invitation_token]
+    self.resource = accept_resource
+    invitation_accepted = resource.errors.empty?
+
+    user_id = resource.id
+    user = User.find(user_id)
+    Member.create(user_id: user_id, plan_id: user.invited_plan_id)
+    yield resource if block_given?
+
+    if invitation_accepted
+      if resource.class.allow_insecure_sign_in_after_accept
+        flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
+        set_flash_message :notice, flash_message if is_flashing_format?
+        resource.after_database_authentication
+        sign_in(resource_name, resource)
+        respond_with resource, location: plans_path
+      else
+        set_flash_message :notice, :updated_not_active if is_flashing_format?
+        respond_with resource, location: new_session_path(resource_name)
+      end
+    else
+      resource.invitation_token = raw_invitation_token
+      respond_with_navigational(resource) { render :edit, status: :unprocessable_entity }
+    end
+  end
 end

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -1,0 +1,39 @@
+class Users::InvitationsController < Devise::InvitationsController
+  # def create
+  #     super
+  #     @member = Member.new
+  #     #Memberテーブルに招待したいユーザーのidを入れる。
+  #     @member.user_id = User.find_by(email: params[:user][:email]).id
+  #     @member.list_id = params[:user][:list_id]
+  #     @member.save
+  # end
+
+  def create
+    user_email = params[:user][:email]
+    plan_id = params[:user][:plan_id]
+    user_id = User.find_by(email: user_email.downcase).id
+    if User.find_by(email: user_email.downcase).present? #　既存ユーザーの処理
+      user = User.find(user_id)
+      if user.plan_ids.include?(plan_id.to_i)
+        redirect_to root_path, alert: "このリストは登録済みです。"
+      else
+      user.invite!
+      @member = Member.new
+      #Memberテーブルに招待したいユーザーのidとリストのidを入れる。
+      @member.user_id = user_id
+      @member.plan_id = plan_id
+      @member.save
+      redirect_to root_path, notice: t('.send_instructions')
+      end
+    elsif User.invite!(email: user_email, plan_id: plan_id) # 新規ユーザーの処理
+      redirect_to plans_path(current_user), notice: t('.send_instructions')
+      @member = Member.new
+      @member.user_id = user_id
+      @member.plan_id = plan_id
+      @member.save
+    else
+      flash[:notice] = t('.failure')
+      render 'new', locals: { plan: plan_id }
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,4 @@
+class Member < ApplicationRecord
+  belongs_to :user
+  belongs_to :plan
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -2,6 +2,8 @@ class Plan < ApplicationRecord
   has_many :planned_spots, dependent: :destroy
   has_many :spots, through: :planned_spots
   belongs_to :owner, class_name: 'User', foreign_key: 'owner_id'
+  has_many :members, dependent: :destroy
+  has_many :users, through: :members
 
   validates :name, presence: true, length: { maximum: 255 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@ class User < ApplicationRecord
   has_many :members, dependent: :destroy
   has_many :plans, through: :members
 
+
+  attr_accessor :plan_id
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_many :plans, foreign_key: 'owner_id'
+  has_many :members, dependent: :destroy
+  has_many :plans, through: :members
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,22 +1,54 @@
-<h2><%= t "devise.invitations.edit.header" %></h2>
+<article class="flex justify-center items-center pt-3">
+  <div class="card shrink-0 max-w-xs md:w-full md:max-w-sm shadow-2xl bg-base-100">
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :invitation_token, readonly: true %>
+    <div class="card-body">
+      <h2 class="text-xl md:text-2xl font-bold mb-1 md:mb-2 underline text-center"><%= t "devise.invitations.edit.header" %></h2>
+      <div class="flex">
+        <p class="text-xs md:text-sm text-center">会員登録をお願いします</p>
+        <div class="dropdown dropdown-end">
+          <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs">
+            <svg tabindex="0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-4 h-4 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+          </div>
+          <div tabindex="0" class="card compact dropdown-content z-[1] shadow bg-secondary rounded-box w-56 md:w-64">
+            <div tabindex="0" class="card-body">
+              <div class="text-xs md:text-sm">
+                <p>会員登録後、プランを確認できます</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-  <% if f.object.class.require_password_on_accepting %>
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password %>
+      <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :invitation_token, readonly: true %>
+
+        <% if f.object.class.require_password_on_accepting %>
+          <div class="form-control my-1">
+            <%= f.label :name, class:"text-sm" %>
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-sm md:input-md input-bordered", placeholder: "名前を入力してね" %>
+          </div>
+
+          <div class="form-control my-1">
+            <%= f.label :email, class:"text-sm" %>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-sm md:input-md input-bordered", placeholder: "メールアドレスを入力してね" %>
+          </div>
+
+          <div class="form-control my-1">
+            <%= f.label :password, class:"text-sm" %>
+            <%= f.password_field :password, autofocus: true, autocomplete: "password", class: "input input-sm md:input-md input-bordered", placeholder: "パスワードを入力してね" %>
+          </div>
+
+          <div class="form-control my-1">
+            <%= f.label :password_confirmation, class:"text-sm" %>
+            <%= f.password_field :password_confirmation, autofocus: true, autocomplete: "password", class: "input input-sm md:input-md input-bordered", placeholder: "再度パスワードを入力してね" %>
+          </div>
+        <% end %>
+
+        <div class="flex justify-center mt-3">
+          <%= f.submit t("devise.invitations.edit.submit_button"), class: "btn btn-sm md:btn-md btn-accent" %>
+        </div>
+      <% end %>
     </div>
-
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit t("devise.invitations.edit.submit_button") %>
   </div>
-<% end %>
+</article>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t "devise.invitations.new.header" %></h2>
 
-<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(@user, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <% resource.class.invite_key_fields.each do |field| -%>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -7,6 +7,8 @@
     <div class="field">
       <%= f.label field %><br />
       <%= f.text_field field %>
+      <!-- plan_idも一緒に設定 -->
+      <%= f.hidden_field :plan_id, value: params[:id] %>
     </div>
   <% end -%>
 

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,6 +1,6 @@
 <p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
 
-<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", name: @user.name) %></p>
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
 
 <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -19,7 +19,7 @@
             <% end %>
           </li>
           <li class="text-xs md:text-lg">
-            <%= link_to "#" do %>
+            <%= link_to new_user_invitation_path(id: @plan.id) do %>
               <span class= "material-symbols-outlined" style= "font-size: 20px;">
                 person_add
               </span>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -9,7 +9,7 @@
   <button class="btn btn-secondary">daisyUI</button>
   <button class="btn btn-info">info</button>
   <button class="btn btn-error">error</button>
-  <button class="btn btn-success">success</button>
+  <%= link_to 'プラン一覧', plans_path, class: "btn btn-success" %>
   <%= link_to '地図を見る', new_plan_path, class: "btn btn-warning" %>
   <%= link_to '会員登録', new_user_registration_path, class: "btn btn-primary" %>
 </div>

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -5,6 +5,7 @@ ja:
     invitations:
       send_instructions: '招待メールが%{email}に送信されました'
       failure: '送信ができませんでした'
+      already_registered_plan: '%{email}はすでにこのプランを登録しています'
       invitation_token_invalid: '招待コードが不正です'
       updated: 'パスワードが設定されました お使いのアカウントでログインできます'
       updated_not_active: 'パスワードが設定されました'
@@ -19,8 +20,8 @@ ja:
     mailer:
       invitation_instructions:
         subject: '旅行メンバーに招待されました'
-        hello: 'こんにちは、%{email}さん'
-        someone_invited_you: '%{url}に招待されました。以下のリンクから承認できます。'
+        hello: '%{email}さん'
+        someone_invited_you: '%{url}に招待されました。以下のリンクから参加できます。'
         accept: 'このプランに参加する'
         accept_until: 'この招待は%{due_date}まで有効です。'
         ignore: '身に覚えがない場合は、このメールを無視してください。'

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -1,20 +1,21 @@
 ja:
   devise:
     failure:
-      invited: 'アカウントを作成するには、保留中の招待を承認してください。'
+      invited: 'アカウントを作成するには、保留中の招待を承認してください'
     invitations:
-      send_instructions: '招待メールが%{email}に送信されました。'
-      invitation_token_invalid: '招待コードが不正です。'
-      updated: 'パスワードが設定されました。お使いのアカウントでログインできます。'
-      updated_not_active: 'パスワードが設定されました。'
-      no_invitations_remaining: 'これ以上招待できません。'
-      invitation_removed: '招待を取り消しました。'
+      send_instructions: '招待メールが%{email}に送信されました'
+      failure: '送信ができませんでした'
+      invitation_token_invalid: '招待コードが不正です'
+      updated: 'パスワードが設定されました お使いのアカウントでログインできます'
+      updated_not_active: 'パスワードが設定されました'
+      no_invitations_remaining: 'これ以上招待できません'
+      invitation_removed: '招待を取り消しました'
       new:
         header: '招待する'
         submit_button: '招待メールを送る'
       edit:
-        header: 'パスワードを設定する'
-        submit_button: 'パスワードを設定する'
+        header: '会員登録'
+        submit_button: '登録'
     mailer:
       invitation_instructions:
         subject: '旅行メンバーに招待されました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   devise_for :users, controllers: {
-    omniauth_callbacks: "omniauth_callbacks"
+    omniauth_callbacks: "omniauth_callbacks",
+    invitations: 'users/invitations'
   }
   
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20240509035154_create_members.rb
+++ b/db/migrate/20240509035154_create_members.rb
@@ -1,0 +1,10 @@
+class CreateMembers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :members do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :plan, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240509080625_add_invited_plan_id_to_users.rb
+++ b/db/migrate/20240509080625_add_invited_plan_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddInvitedPlanIdToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :invited_plan_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_014941) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_035154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "members", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "plan_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id"], name: "index_members_on_plan_id"
+    t.index ["user_id"], name: "index_members_on_user_id"
+  end
 
   create_table "planned_spots", force: :cascade do |t|
     t.bigint "plan_id", null: false
@@ -67,6 +76,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_014941) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "members", "plans"
+  add_foreign_key "members", "users"
   add_foreign_key "planned_spots", "plans"
   add_foreign_key "planned_spots", "spots"
   add_foreign_key "plans", "users", column: "owner_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_035154) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_080625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_035154) do
     t.string "provider"
     t.string "uid"
     t.string "name", default: "", null: false
+    t.integer "invited_plan_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"


### PR DESCRIPTION
### 概要
招待リンクを開いて会員登録すると自分のplanとして保存される

### 実装ページ
- 招待側ページ
![8c35e3f8ba128dea8698b7f3ff1ca288](https://github.com/maru973/Tripot_Share/assets/148407473/d9e8b7de-65f6-4137-8e97-7bbcd636de6a)

- 招待された側ページ
![6d11a13044e414bd1c6c2de290aea588](https://github.com/maru973/Tripot_Share/assets/148407473/57c34382-4551-4e78-b76d-a6d9559deb88)

- すでにプランに参加してる人を招待しようとした場合
![bd9b98a0094242fcb441b2abbc0f0e29](https://github.com/maru973/Tripot_Share/assets/148407473/27d895f8-fa8b-458d-81f3-b62ef4924a70)

- コンソール
<img width="667" alt="4f1917eea5232396c756efa467a67c43" src="https://github.com/maru973/Tripot_Share/assets/148407473/7a64ca3b-bb76-45f4-918c-92a5d52698ce">


### 内容
- [x] 既存ユーザーにもメール送信ができるよう設定
- [x] plan_idを一時的にUsersテーブルのinvited_plan_idに保存
- [x] 招待リンクを押して会員登録をすると招待したplanがそのユーザーに紐づく
- [x] membersテーブルの作成
- [x] planを新規作成したときにmembersテーブルに保存される      
