### PR TITLE
【feature】招待リンクの生成 close #25

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,22 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+turbo-frame {
+  border: 1px red solid;
+  display: block;
+}
+
+turbo-frame::before {
+  content: "Frame: #" attr(id);
+  position: relative;
+  top: -14px;
+  right: -4px;
+  display: inline-block;
+  color: red;
+  font-size: 12px;
+  z-index: 9999;
+  background-color: white;
+  padding: 4px;
+  border: 1px red solid;
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,22 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-turbo-frame {
-  border: 1px red solid;
-  display: block;
-}
-
-turbo-frame::before {
-  content: "Frame: #" attr(id);
-  position: relative;
-  top: -14px;
-  right: -4px;
-  display: inline-block;
-  color: red;
-  font-size: 12px;
-  z-index: 9999;
-  background-color: white;
-  padding: 4px;
-  border: 1px red solid;
-}

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -35,6 +35,13 @@ class PlansController < ApplicationController
   private
 
   def plan_params
-    params.require(:plan).permit(:name, :start_date, :end_date)
+    params.require(:plan).permit(:name, :start_date, :end_date, :invite_token)
+  end
+
+  def generate_token
+    invitation_token = Devise.friendly_token
+    plan.update(invitation_token: invitation_token )
+
+    redirect_to plan_path(plan), notice: "#{plan.name}の招待リンクを作成しました リンクをコピーして招待したい人にURLを送りましょう"
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -31,11 +31,20 @@ class PlansController < ApplicationController
     @spots = @plan.spots
     @user = User.new
     @resource_name = @user.class.name.underscore
+    @invite_url = accept_plan_url(invitation_token: @plan.invitation_token) if @plan.invitation_token.present?
+  end
+
+  def invitation
+    @plan = Plan.find(params[:id])
+    @plan.generate_token
+  end
+
+  def accept
   end
 
   private
 
   def plan_params
-    params.require(:plan).permit(:name, :start_date, :end_date, :invite_token)
+    params.require(:plan).permit(:name, :start_date, :end_date, :invitation_token)
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -31,7 +31,7 @@ class PlansController < ApplicationController
     @spots = @plan.spots
     @user = User.new
     @resource_name = @user.class.name.underscore
-    @invite_url = accept_plan_url(invitation_token: @plan.invitation_token) if @plan.invitation_token.present?
+    @invite_link = accept_plan_url(invitation_token: @plan.invitation_token) if @plan.invitation_token.present?
   end
 
   def invitation

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -21,6 +21,7 @@ class PlansController < ApplicationController
 
   def new_spots
     @plan = Plan.find(params[:id])
+    @plna.generate_token
     @spot = Spot.new
     @spots = @plan.spots
   end
@@ -36,12 +37,5 @@ class PlansController < ApplicationController
 
   def plan_params
     params.require(:plan).permit(:name, :start_date, :end_date, :invite_token)
-  end
-
-  def generate_token
-    invitation_token = Devise.friendly_token
-    plan.update(invitation_token: invitation_token )
-
-    redirect_to plan_path(plan), notice: "#{plan.name}の招待リンクを作成しました リンクをコピーして招待したい人にURLを送りましょう"
   end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -27,4 +27,10 @@ class Plan < ApplicationRecord
       errors.add(:end_date, '今日以降の日付に設定してください')
     end
   end
+
+  # トークン生成のためのメソッド
+  def generate_token
+    self.invitation_token = Devise.friendly_token
+    save
+  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -9,6 +9,12 @@ class Plan < ApplicationRecord
 
   validate :dates_check
 
+   # トークン生成のためのメソッド
+  def generate_token
+   self.invitation_token = Devise.friendly_token
+   save
+  end
+
   private
 
   def dates_check
@@ -26,11 +32,5 @@ class Plan < ApplicationRecord
     if end_date.present? && end_date < Date.today
       errors.add(:end_date, '今日以降の日付に設定してください')
     end
-  end
-
-  # トークン生成のためのメソッド
-  def generate_token
-    self.invitation_token = Devise.friendly_token
-    save
   end
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -27,6 +27,8 @@
         <% end -%>
 
       <% end %>
+
+      <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post} %>
     </dialog>
 
  

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -27,8 +27,9 @@
         <% end -%>
 
       <% end %>
-
-      <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post} %>
+      <turbo-frame id="invite_link">
+        <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
+      </turbo-frame>
     </dialog>
 
  

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag 'modal' do %>
 
-    <dialog data-modal-target="dialog" class="p-8 rounded-lg backdrop:bg-black/50 text-base-content">
+    <dialog data-modal-target="dialog" class="p-6 rounded-lg backdrop:bg-black/50 text-base-content">
       <div class="flex justify-end">
         <button autofocus data-action="modal#close">
           <span class="material-symbols-outlined">
@@ -21,15 +21,18 @@
             <%= f.hidden_field :plan_id, value: params[:id] %>
 
             <div class="actions">
-              <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-sm md:btn-md btn-accent rounded-none rounded-r-lg" %>
+              <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-sm md:btn-md btn-secondary rounded-none rounded-r-lg" %>
             </div>
           </div>
         <% end -%>
 
       <% end %>
-      <turbo-frame id="invite_link">
-        <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
-      </turbo-frame>
+      <%= turbo_frame_tag 'invite_link' do %>
+        <%= render 'plans/invitation_url_button' %>
+        <div class="flex justify-center">
+          <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
+        </div>
+      <% end %>
     </dialog>
 
  

--- a/app/views/plans/_invitation_url_button.html.erb
+++ b/app/views/plans/_invitation_url_button.html.erb
@@ -1,7 +1,13 @@
 
-
 <%= turbo_frame_tag 'invite_link' do %>
-    <% if @invite_link.present? %>
-      <%= @invite_link %>
-    <%end%>
+  <% if @invite_link.present? %>
+    <div class="flex flex-col ">
+      <div data-clipboard-target='link' class="underline">
+        <%= @invite_link %>
+      </div>
+      <button data-action="clipboard#copyToClipboard" class="btn btn-xs text-xs sm:text-sm">
+        リンクをコピーする
+      </button>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/plans/_invitation_url_button.html.erb
+++ b/app/views/plans/_invitation_url_button.html.erb
@@ -1,0 +1,13 @@
+
+
+<%= link_to "リンクを生成", onclick="my_modal_2.showModal()", invitation_plan_path, class:"btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post} %>
+<dialog id="my_modal_2" class="modal">
+  <div class="modal-box">
+    <% if @invite_link.present? %>
+      <%= @invite_link %>
+    <%end%>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/app/views/plans/_invitation_url_button.html.erb
+++ b/app/views/plans/_invitation_url_button.html.erb
@@ -1,13 +1,7 @@
 
 
-<%= link_to "リンクを生成", onclick="my_modal_2.showModal()", invitation_plan_path, class:"btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post} %>
-<dialog id="my_modal_2" class="modal">
-  <div class="modal-box">
+<%= turbo_frame_tag 'invite_link' do %>
     <% if @invite_link.present? %>
       <%= @invite_link %>
     <%end%>
-  </div>
-  <form method="dialog" class="modal-backdrop">
-    <button>close</button>
-  </form>
-</dialog>
+<% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -111,19 +111,8 @@
   <!-- シェアボタン　--> 
   <div class="flex justify-center mt-3">
     <%= link_to "一覧ページへ戻る", "#", class:"btn btn-accent btn-sm md:btn-lg" %>
-  </div>
-  <% if @invite_link.present? %>
-          <div class="flex flex-col sm:flex-row justify-center items-center space-x-4 mx-auto">
-            <div data-clipboard-target='link' class="text-gray-500 text-sm sm:text-base underline mb-2 sm:mb-0 overflow-wrap break-words overflow-x-auto w-full max-w-screen-sm">
-              <%= @invite_link %>
-            </div>
-            <button data-action="clipboard#copyToClipboard" class="btn btn-xs text-xs sm:text-sm">
-              リンクをコピーする
-            </button>
-          </div>
-        <% end %>
-        
-
+  </div>       
+  <%= render 'plans/invitation_url_button' %>
 </article>
 
 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -112,6 +112,18 @@
   <div class="flex justify-center mt-3">
     <%= link_to "一覧ページへ戻る", "#", class:"btn btn-accent btn-sm md:btn-lg" %>
   </div>
+  <% if @invite_link.present? %>
+          <div class="flex flex-col sm:flex-row justify-center items-center space-x-4 mx-auto">
+            <div data-clipboard-target='link' class="text-gray-500 text-sm sm:text-base underline mb-2 sm:mb-0 overflow-wrap break-words overflow-x-auto w-full max-w-screen-sm">
+              <%= @invite_link %>
+            </div>
+            <button data-action="clipboard#copyToClipboard" class="btn btn-xs text-xs sm:text-sm">
+              リンクをコピーする
+            </button>
+          </div>
+        <% end %>
+        
+
 </article>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
     resources :spots, only: %i[create destroy], shallow: true
     member do
       get 'course'
+      post 'invitation'
+      get 'invitation/accept/:invitation_token', to: 'plans#accept', as: 'accept'
       
       #今後必要があれば
       # get 'courses'

--- a/db/migrate/20240511023948_add_invitation_token_to_plans.rb
+++ b/db/migrate/20240511023948_add_invitation_token_to_plans.rb
@@ -1,0 +1,6 @@
+class AddInvitationTokenToPlans < ActiveRecord::Migration[7.1]
+  def change
+    add_column :plans, :invitation_token, :string
+    add_index :plans, :invitation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_080625) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_023948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_080625) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "owner_id", null: false
+    t.string "invitation_token"
+    t.index ["invitation_token"], name: "index_plans_on_invitation_token", unique: true
   end
 
   create_table "spots", force: :cascade do |t|


### PR DESCRIPTION
### 概要
招待リンクの生成

### 実際のページ
<img width="698" alt="b480e65dafe033182cb4e0cc2030dcf3" src="https://github.com/maru973/Tripot_Share/assets/148407473/5bd0ec20-fa32-428c-ac6d-33e6dcf808bb">


### 内容
- [x] plansテーブルにinvitation_tokenカラムの追加
- [x] URL作成ボタンを押すとトークンが生成され、invitation_tokenカラムに保存される
- [x]  招待機能のモーダル内でURLを表示


### 補足
現在リロードしたらURLが表示される。
トークンを押してもまだビューは表示されずエラーになる状態。
