### PR TITLE
【feature】招待リンクに飛んだらplan_idがそのユーザーに登録される close #116

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -12,7 +12,7 @@ class PlansController < ApplicationController
     @plan.owner_id = current_user.id
     if @plan.save
       @plan.users << current_user
-      redirect_to new_spots_path(@plan), notice: t('defaults.flash_message.created', item: Plan.model_name.human)
+      redirect_to new_spots_path(@plan), notice: t('defaults.flash_message.created', item: @plan.name)
     else
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Plan.model_name.human)
       render :new, status: :unprocessable_entity
@@ -50,16 +50,16 @@ class PlansController < ApplicationController
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
 
-        redirect_to plans_path, notice: "#{@plan.name}に追加されました"
+        redirect_to plans_path, notice: t('defaults.flash_message.added', item: @plan.name)
       elsif user_signed_in? && Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
-        redirect_to plan_path(@plan), notice: "#{@plan.name}はすでに登録しています"
+        redirect_to plan_path(@plan), notice:t('defaults.flash_message.already_registered_plan', item: @plan.name)
       else
         redirect_to new_user_registration_path
       end
     else
-      redirect_to root_path, alert: "この招待コードは不正です メンバーにURLの発行を依頼してください"
+      redirect_to root_path, alert: t('defaults.flash_message.invitation_token_invalid')
     end
   end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -40,6 +40,22 @@ class PlansController < ApplicationController
   end
 
   def accept
+    @plan = Plan.find_by(invitation_token: params[:invitation_token])
+    session[:plan_id] = @plan.id
+
+    if user_signed_in? && !Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+      @plan.users << current_user
+      session[:plan_id] = nil
+      @plan.update(invitation_token: nil)
+
+      redirect_to plans_path, notice: "#{@plan.name}に追加されました"
+    elsif user_signed_in? && Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+      session[:plan_id] = nil
+      @plan.update(invitation_token: nil)
+      redirect_to plan_path(@plan), notice: "#{@plan.name}はすでに登録しています"
+    else
+      redirect_to new_user_registration_path
+    end
   end
 
   private

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -41,20 +41,25 @@ class PlansController < ApplicationController
 
   def accept
     @plan = Plan.find_by(invitation_token: params[:invitation_token])
-    session[:plan_id] = @plan.id
+    
+    if @plan.present?
+      
+      session[:plan_id] = @plan.id
+      if user_signed_in? && !Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+        @plan.users << current_user
+        session[:plan_id] = nil
+        @plan.update(invitation_token: nil)
 
-    if user_signed_in? && !Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
-      @plan.users << current_user
-      session[:plan_id] = nil
-      @plan.update(invitation_token: nil)
-
-      redirect_to plans_path, notice: "#{@plan.name}に追加されました"
-    elsif user_signed_in? && Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
-      session[:plan_id] = nil
-      @plan.update(invitation_token: nil)
-      redirect_to plan_path(@plan), notice: "#{@plan.name}はすでに登録しています"
+        redirect_to plans_path, notice: "#{@plan.name}に追加されました"
+      elsif user_signed_in? && Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+        session[:plan_id] = nil
+        @plan.update(invitation_token: nil)
+        redirect_to plan_path(@plan), notice: "#{@plan.name}はすでに登録しています"
+      else
+        redirect_to new_user_registration_path
+      end
     else
-      redirect_to new_user_registration_path
+      redirect_to root_path, alert: "この招待コードは不正です メンバーにURLの発行を依頼してください"
     end
   end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -50,14 +50,15 @@ class PlansController < ApplicationController
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
 
-        redirect_to plans_path, notice: t('defaults.flash_message.added', item: @plan.name)
+        redirect_to plan_path(@plan), notice: t('defaults.flash_message.added', item: @plan.name)
+
       elsif user_signed_in? && Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
+
         redirect_to plan_path(@plan), notice:t('defaults.flash_message.already_registered_plan', item: @plan.name)
-      else
-        redirect_to new_user_registration_path
       end
+
     else
       redirect_to root_path, alert: t('defaults.flash_message.invitation_token_invalid')
     end

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -5,7 +5,7 @@ ja:
     invitations:
       send_instructions: '招待メールが%{email}に送信されました'
       failure: '送信ができませんでした'
-      already_registered_plan: '%{email}はすでにこのプランを登録しています'
+      already_registered_plan: '%{email}はすでにこのプランのメンバーです'
       invitation_token_invalid: '招待コードが不正です'
       updated: 'パスワードが設定されました お使いのアカウントでログインできます'
       updated_not_active: 'パスワードが設定されました'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,10 @@ ja:
     flash_message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"
+      added: "%{item}のメンバーに追加されました"
+      already_registered_plan: "すでに%{item}のメンバーです"
+      invitation_token_invalid: "この招待コードは不正です メンバーにURLの再発行を依頼してください"
+
   plans:
     index:
       title: プラン一覧


### PR DESCRIPTION
### 概要
招待リンクに飛んだらplan_idがそのユーザーに登録される

### 実装ページ
- メンバー追加
![1615b0e9119b8e5b0edc00f08160d287](https://github.com/maru973/Tripot_Share/assets/148407473/9f01264e-b6fe-43c6-8287-ebffca630ac4)


- すでにメンバーの場合
![934aec96e741c56d90870098a9fb896a](https://github.com/maru973/Tripot_Share/assets/148407473/7a053869-1cb3-43a5-9795-a789a51aed61)

- 一度招待で使用したURLを使おうとしてもエラーになる
![02999e71d1506918013c6ee6512f1bc0](https://github.com/maru973/Tripot_Share/assets/148407473/d9f98a2b-d91b-4abc-9678-b8797fd4f98d)


### 内容
- [x] 招待されたユーザーがURLをクリックするとログインしている場合はplan_idがそのユーザーに保存される
- [x] ログインしてない場合（未会員の場合）、ログイン画面に遷移する
- [x] 招待URLは都度発行しないと招待できない
- [x] 一度プランを追加したtokenはカラムをnilにして使用しようとしてもエラーメッセージを表示
