### PR TITLE
【feature】メンバーのみスポット登録ができる close #26

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -21,7 +21,7 @@ class PlansController < ApplicationController
 
   def new_spots
     @plan = Plan.find(params[:id])
-    if Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+    if current_user.member?(@plan.id)
       @spot = Spot.new
       @spots = @plan.spots
     else
@@ -48,14 +48,14 @@ class PlansController < ApplicationController
     if @plan.present?
       
       session[:plan_id] = @plan.id
-      if user_signed_in? && !Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+      if user_signed_in? && !current_user.member?(@plan.id)
         @plan.users << current_user
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
 
         redirect_to plan_path(@plan), notice: t('defaults.flash_message.added', item: @plan.name)
 
-      elsif user_signed_in? && Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+      elsif user_signed_in? && current_user.member?(@plan.id)
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -21,9 +21,12 @@ class PlansController < ApplicationController
 
   def new_spots
     @plan = Plan.find(params[:id])
-    @plna.generate_token
-    @spot = Spot.new
-    @spots = @plan.spots
+    if Member.find_by(plan_id: @plan.id, user_id: current_user.id).present?
+      @spot = Spot.new
+      @spots = @plan.spots
+    else
+      redirect_to plan_path(@plan), alert: "あなたはこのプランのメンバーではないため、スポットの登録はできません"
+    end
   end
 
   def show

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -12,7 +12,7 @@ class PlansController < ApplicationController
     @plan.owner_id = current_user.id
     if @plan.save
       @plan.users << current_user
-      redirect_to new_spots_path(@plan), notice: t('defaults.flash_message.created', item: @plan.name)
+      redirect_to new_spots_plan_path(@plan), notice: t('defaults.flash_message.created', item: @plan.name)
     else
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Plan.model_name.human)
       render :new, status: :unprocessable_entity

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,9 @@ class User < ApplicationRecord
     credentials = credentials.to_json
     name = info["name"]
   end
+
+  # planのメンバーかどうかを判断するメソッド
+  def member?(plan_id)
+    self.plans.find_by(id: plan_id).present?
+  end
 end

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -2,6 +2,7 @@
   <div class="flex items-center">
     <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7"><%= @plan.name %></h2>
 
+    <% if current_user.member?(@plan.id) %>
      <!-- 追加メニュー -->
       <div class="flex-none dropdown dropdown-end">
         <div tabindex="0" role="button" class="pt-1 md:pr-5">
@@ -32,6 +33,7 @@
           </li>
         </ul>
       </div>
+    <% end %>
   </div>
 
   <!-- 地図の表示 -->

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center">
     <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7"><%= @plan.name %></h2>
 
-      <!-- 追加メニュー -->
+     <!-- 追加メニュー -->
       <div class="flex-none dropdown dropdown-end">
         <div tabindex="0" role="button" class="pt-1 md:pr-5">
           <div class="material-symbols-outlined">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -12,7 +12,7 @@
         </div>
         <ul tabindex="0" class="border dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-40 md:w-52">
           <li class="text-xs md:text-lg">
-            <%= link_to new_spots_path(@plan) do %>
+            <%= link_to new_spots_plan_path(@plan) do %>
               <span class= "material-symbols-outlined" style= "font-size: 20px;">
                 add_location_alt
               </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,11 +14,11 @@ Rails.application.routes.draw do
   get '/terms_of_service', to: 'staticpages#terms_of_service'
   get '/contact_us', to: 'staticpages#contact_us'
   
-  get '/plans/:id/new_spots', to: 'plans#new_spots', as: 'new_spots'
-
+  
   resources :plans do
     resources :spots, only: %i[create destroy], shallow: true
     member do
+      get 'new_spots'
       get 'course'
       post 'invitation'
       get 'invitation/accept/:invitation_token', to: 'plans#accept', as: 'accept'


### PR DESCRIPTION
### 概要
メンバーのみスポット登録ができる

### 実装ページ
- メンバーの場合
![6c26fd85e197d568f19c251ccd34fbd3](https://github.com/maru973/Tripot_Share/assets/148407473/3dc641b0-9fa2-4f5a-87a9-a01ac3362952)

- メンバー以外の場合
![bfa9ad9df517e111745e3b9bba2a4ee2](https://github.com/maru973/Tripot_Share/assets/148407473/3b11cc64-4a20-4011-bc6d-79f2dcf05d96)



### 内容
- [x]  ユーザーがプランのメンバーの場合のみスポット登録画面が表示できる
- [x] メンバー以外はshowページに遷移し、エラーメッセージが表示される
- [x] Userモデルにmember?メソッドを定義  
- [x] メンバー以外はshowページの追加ボタンが表示されない


### 補足
showページは誰でも閲覧できるようにしている。
今後の展望としてはプラン一覧とプラン詳細までは誰でも閲覧して参考にできるようにしたい。