### PR TITLE
【feature】google maps APIからスポットの詳細情報を取得し、テーブルに保存 close #119

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,5 +72,6 @@ gem 'geocoder'
 gem 'kaminari'
 gem 'rails-i18n'
 gem 'devise_invitable'
+gem 'google_places'
 
 gem "dockerfile-rails", ">= 1.6", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -120,7 +121,13 @@ GEM
     geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google_places (2.0.0)
+      httparty (>= 0.13.1)
     hashie (5.0.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -320,6 +327,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv-rails
   geocoder
+  google_places
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -7,6 +7,14 @@ class SpotsController < ApplicationController
       @spot.latitude = @latlng[0]
       @spot.longitude = @latlng[1]
       @spot.address = results.first.address
+      
+      spot_details = @spot.get_spot_details(spot_params[:name])
+      if spot_details
+        @spot.opening_hours = spot_details[:opening_hours]
+        @spot.website = spot_details[:website]
+        @spot.phone_number = spot_details[:phone_number]
+      end
+
       @spot.save
     end
     @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -5,4 +5,33 @@ class Spot < ApplicationRecord
 
   geocoded_by :address
   after_validation :geocode, if: ->(obj){ obj.address.present? and obj.address_changed? }
+
+  # Spot.newされたら呼び出す
+  after_initialize :set_google_client
+
+  # place_idを取得する
+  def get_place_id(name)
+    spot = @client.spots_by_query(name).first
+    spot.place_id if spot
+  end
+
+  # place_idからスポットの詳細情報を取得する
+  def get_spot_details(name)
+    place_id = get_place_id(name)
+    return nil unless place_id
+
+    spot_details = @client.spot(place_id, fields: 'place_id,opening_hours,website,formatted_phone_number', language: 'ja')
+    {
+      opening_hours: spot_details.opening_hours&.[]('weekday_text'),
+      website: spot_details.website ? spot_details.website : nil,
+      phone_number: spot_details.formatted_phone_number ? spot_details.formatted_phone_number : nil
+    }
+  end
+
+  private
+
+  def set_google_client
+    # @clientがnilの時は値を代入して、値が入っていればその値をそのまま使う
+    @client ||= GooglePlaces::Client.new(ENV['GOOGLEMAPS_API_KEY'])
+  end
 end

--- a/db/migrate/20240513014732_add_column_spots.rb
+++ b/db/migrate/20240513014732_add_column_spots.rb
@@ -1,7 +1,7 @@
 class AddColumnSpots < ActiveRecord::Migration[7.1]
   def change
     add_column :spots, :opening_hours, :string
-    add_column :spots, :phone_number, :integer
+    add_column :spots, :phone_number, :string
     add_column :spots, :website, :string
   end
 end

--- a/db/migrate/20240513014732_add_column_spots.rb
+++ b/db/migrate/20240513014732_add_column_spots.rb
@@ -1,0 +1,7 @@
+class AddColumnSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :spots, :opening_hours, :string
+    add_column :spots, :phone_number, :integer
+    add_column :spots, :website, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_11_023948) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_014732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_11_023948) do
     t.float "longitude", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "opening_hours"
+    t.string "phone_number"
+    t.string "website"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### 概要
google maps APIからスポットの詳細情報を取得し、テーブルに保存

### 実装ページ
<img width="671" alt="3b8f59f81124de2a8dc1172a33d17484" src="https://github.com/maru973/Tripot_Share/assets/148407473/72aa3259-8588-47aa-88b1-b37fad25d5ae">



### 内容
- [x]  gem 'google_places'を追加
- [x] place_idを取得後、必要な詳細情報を取得
- [x] 詳細情報を該当カラムに代入して保存（新規スポットのみ）
- [x] Spotsテーブルに営業時間、電話番号、ウェブサイトのカラムを追加 


### 補足
写真を今後保存するかどうかは様子を見て決める。