### PR TITLE
【feature】スポット詳細のモーダルを表示 close #24

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -10,7 +10,7 @@ class SpotsController < ApplicationController
       
       spot_details = @spot.get_spot_details(spot_params[:name])
       if spot_details
-        @spot.opening_hours = spot_details[:opening_hours]
+        @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n")
         @spot.website = spot_details[:website]
         @spot.phone_number = spot_details[:phone_number]
       end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -10,7 +10,7 @@ class SpotsController < ApplicationController
       
       spot_details = @spot.get_spot_details(spot_params[:name])
       if spot_details
-        @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n")
+        @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
         @spot.website = spot_details[:website]
         @spot.phone_number = spot_details[:phone_number]
       end

--- a/app/views/spots/_modal.html.erb
+++ b/app/views/spots/_modal.html.erb
@@ -14,36 +14,42 @@
     <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= spot.name %></h2>
     <div class="md:text-lg">
       <p>住所：<%= spot.address %></p>
-      <p class="m-2">
-        <span class="material-symbols-outlined" style= "font-size: 18px;">
-          call
-        </span>
-        :
-        <button class="link link-primary">
-          <%= spot.phone_number %>
-        </button>
-      </p>
-      <div class="m-2">
-        <div class="flex">
-          <p class="font-bold underline">営業時間</p>
-          <div class="dropdown dropdown-right">
-            <div tabindex="0" role="button" class="m-1">
-              <span class="material-symbols-outlined" style= "font-size: 18px;">
-                info
-              </span>
+      <% if spot.phone_number.present? %>
+        <p class="m-2">
+          <span class="material-symbols-outlined" style= "font-size: 18px;">
+            call
+          </span>
+          :
+          <button class="link link-primary">
+            <%= spot.phone_number %>
+          </button>
+        </p>
+      <% end %>
+      <% if spot.opening_hours.present? %>
+        <div class="m-2">
+          <div class="flex">
+            <p class="font-bold underline">営業時間</p>
+            <div class="dropdown dropdown-right">
+              <div tabindex="0" role="button" class="m-1">
+                <span class="material-symbols-outlined" style= "font-size: 18px;">
+                  info
+                </span>
+              </div>
+            <div tabindex="0" class="dropdown-content z-[1] p-2 w-40 shadow bg-accent rounded-lg text-center">
+              <p class="text-sm">今日は<%= l(Date.today, format: :day_name) %>です</p>
             </div>
-          <div tabindex="0" class="dropdown-content z-[1] p-2 w-40 shadow bg-accent rounded-lg text-center">
-            <p class="text-sm">今日は<%= l(Date.today, format: :day_name) %>です</p>
           </div>
+          </div>
+          <ul class="pl-5">
+            <% spot.opening_hours.split("\n").each do |hour| %>
+              <li><%= hour %></li>
+            <% end %>
+          </ul>
         </div>
-        </div>
-        <ul class="pl-5">
-          <% spot.opening_hours.split("\n").each do |hour| %>
-            <li><%= hour %></li>
-          <% end %>
-        </ul>
-      </div>
-      <%= link_to "ウェブサイトはこちら", spot.website, target: "_blank", class: "link link-primary" %>
+      <% end %>
+      <% if spot.website.present? %>
+        <%= link_to "ウェブサイトはこちら", spot.website, target: "_blank", class: "link link-primary" %>
+      <% end %>
     </div>
   </dialog>
 </div>

--- a/app/views/spots/_modal.html.erb
+++ b/app/views/spots/_modal.html.erb
@@ -12,9 +12,38 @@
       </button>
     </div>
     <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= spot.name %></h2>
-    <p class="md:text-lg opacity-50"><%= spot.address %></p>
-    <p><%= spot.opening_hours %></p>
-    <p><%= spot.phone_number %></p>
-    <p><%= spot.website %></p>    
+    <div class="md:text-lg">
+      <p>住所：<%= spot.address %></p>
+      <p class="m-2">
+        <span class="material-symbols-outlined" style= "font-size: 18px;">
+          call
+        </span>
+        :
+        <button class="link link-primary">
+          <%= spot.phone_number %>
+        </button>
+      </p>
+      <div class="m-2">
+        <div class="flex">
+          <p class="font-bold underline">営業時間</p>
+          <div class="dropdown dropdown-right">
+            <div tabindex="0" role="button" class="m-1">
+              <span class="material-symbols-outlined" style= "font-size: 18px;">
+                info
+              </span>
+            </div>
+          <div tabindex="0" class="dropdown-content z-[1] p-2 w-40 shadow bg-accent rounded-lg text-center">
+            <p class="text-sm">今日は<%= l(Date.today, format: :day_name) %>です</p>
+          </div>
+        </div>
+        </div>
+        <ul class="pl-5">
+          <% spot.opening_hours.split("\n").each do |hour| %>
+            <li><%= hour %></li>
+          <% end %>
+        </ul>
+      </div>
+      <%= link_to "ウェブサイトはこちら", spot.website, target: "_blank", class: "link link-primary" %>
+    </div>
   </dialog>
 </div>

--- a/app/views/spots/_modal.html.erb
+++ b/app/views/spots/_modal.html.erb
@@ -1,0 +1,20 @@
+<div data-controller="modal">
+  <div class="link link-hover" data-action="click->modal#open">
+    <div class="text-md md:text-lg"><%= spot.name %></div>
+    <div class="text-xs md:text-sm opacity-50 truncate"><%= spot.address %></div>
+  </div>
+  <dialog data-modal-target="dialog" class="max-w-[500px] p-6 rounded-lg backdrop:bg-black/50 text-base-content">
+    <div class="flex justify-end">
+      <button autofocus data-action="modal#close">
+        <span class="material-symbols-outlined">
+          close
+        </span>
+      </button>
+    </div>
+    <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= spot.name %></h2>
+    <p class="md:text-lg opacity-50"><%= spot.address %></p>
+    <p><%= spot.opening_hours %></p>
+    <p><%= spot.phone_number %></p>
+    <p><%= spot.website %></p>    
+  </dialog>
+</div>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,10 +1,7 @@
 <tr id="spot-<%= spot.id %>">
   <td>1</td>
-  <td>
-    <%= link_to "#", class:"link link-hover" do %>
-      <div class="text-md md:text-lg"><%= spot.name %></div>
-      <div class="text-xs md:text-sm opacity-50 truncate"><%= spot.address %></div>
-    <% end %>
+  <td>  
+    <%= render 'spots/modal', spot: spot %>
   </td>
   <td>
     <%= link_to "#", class:"hover:brightness-75" do %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,15 @@
 ja:
+  date:
+    formats:
+      day_name: "%A"
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
   views:
     pagination:
       truncate: "..."
@@ -11,7 +22,6 @@ ja:
       added: "%{item}のメンバーに追加されました"
       already_registered_plan: "すでに%{item}のメンバーです"
       invitation_token_invalid: "この招待コードは不正です メンバーにURLの再発行を依頼してください"
-
   plans:
     index:
       title: プラン一覧


### PR DESCRIPTION
### 概要
スポット詳細のモーダルを表示

### 実装ページ
<img width="554" alt="c69fbdb6839d60e18dfb80af23a8161a" src="https://github.com/maru973/Tripot_Share/assets/148407473/8d924a1d-ac21-40d4-9f41-6ef507364625">


### 内容
- [x] リストのスポット名をクリックするとスポット詳細情報のモーダルを表示
- [x]  opening_hoursのデータを表示できるように処理するメソッドの追加
- [x]  データがnilの時は表示しないように設定
- [x] 現在の曜日を日本語で表示
