### PR TITLE
【feature】スポット削除機能の実装 close #44

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.material-symbols-outlined {
+  text-color: #592926;
+}

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -24,7 +24,7 @@ class SpotsController < ApplicationController
   end
 
   def destroy
-    @plan = Plan.find(params[:id])
+    @plan = Plan.find(params[:plan_id])
     @spot = Spot.find(params[:id])
     @planned_spot = @plan.planned_spots.find_by(spot_id: @spot.id)
     @planned_spot.destroy!

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -23,6 +23,13 @@ class SpotsController < ApplicationController
     end
   end
 
+  def destroy
+    @plan = Plan.find(params[:id])
+    @spot = Spot.find(params[:id])
+    @planned_spot = @plan.planned_spots.find_by(spot_id: @spot.id)
+    @planned_spot.destroy!
+  end
+
   private
 
   def spot_params

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -6,7 +6,7 @@
       <div class="flex">
         <p class="text-xs md:text-sm text-center">会員登録をお願いします</p>
         <div class="dropdown dropdown-end">
-          <div tabindex="0" role="button" class="btn btn-circle btn-ghost btn-xs">
+          <div tabindex="0" role="button" class="text-base-content btn btn-circle btn-ghost btn-xs">
             <svg tabindex="0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-4 h-4 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
           </div>
           <div tabindex="0" class="card compact dropdown-content z-[1] shadow bg-secondary rounded-box w-56 md:w-64">
@@ -46,7 +46,7 @@
         <% end %>
 
         <div class="flex justify-center mt-3">
-          <%= f.submit t("devise.invitations.edit.submit_button"), class: "btn btn-sm md:btn-md btn-accent" %>
+          <%= f.submit t("devise.invitations.edit.submit_button"), class: "text-base-content btn btn-sm md:btn-md btn-accent" %>
         </div>
       <% end %>
     </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -21,7 +21,7 @@
             <%= f.hidden_field :plan_id, value: params[:id] %>
 
             <div class="actions">
-              <%= f.submit t("devise.invitations.new.submit_button"), class: "btn btn-sm md:btn-md btn-secondary rounded-none rounded-r-lg" %>
+              <%= f.submit t("devise.invitations.new.submit_button"), class: "text-base-content btn btn-sm md:btn-md btn-secondary rounded-none rounded-r-lg" %>
             </div>
           </div>
         <% end -%>
@@ -30,7 +30,7 @@
       <%= turbo_frame_tag 'invite_link' do %>
         <%= render 'plans/invitation_url_button' %>
         <div class="flex justify-center">
-          <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
+          <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"text-base-content btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
         </div>
       <% end %>
     </dialog>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -45,7 +45,7 @@
         </div>
 
         <div class="flex justify-center mt-3">
-          <%= f.submit t('.sign_up'), class: "btn btn-sm md:btn-md btn-accent" %>
+          <%= f.submit t('.sign_up'), class: "text-base-content btn btn-sm md:btn-md btn-accent" %>
         </div>
       <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -41,7 +41,7 @@
         <% end %> -->
 
         <div class="flex justify-center mt-3">
-          <%= f.submit t('.sign_in'), class: "btn btn-sm md:btn-md btn-accent" %>
+          <%= f.submit t('.sign_in'), class: "text-base-content btn btn-sm md:btn-md btn-accent" %>
         </div>
       <% end %>
 

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="first">
-  <%= link_to_unless current_page.first?, "««", url, {remote: remote, class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
+  <%= link_to_unless current_page.first?, "««", url, {remote: remote, class: "join-item text-base-content btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -6,5 +6,5 @@
     remote:        data-remote
 -%>
 <div class="page gap">
-  <%= t('views.pagination.truncate').html_safe, class: "join-item btn-sm md:btn-md btn btn-disabled" %>
+  <%= t('views.pagination.truncate').html_safe, class: "join-item text-base-content btn-sm md:btn-md btn btn-disabled" %>
 </div>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="last">
-  <%= link_to_unless current_page.last?, "»»", url, {remote: remote, class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
+  <%= link_to_unless current_page.last?, "»»", url, {remote: remote, class: "join-item text-base-content btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="next">
-  <%= link_to_unless current_page.last?, "»", url, {remote: remote, rel: 'next', class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
+  <%= link_to_unless current_page.last?, "»", url, {remote: remote, rel: 'next', class: "join-item text-base-content btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -10,10 +10,10 @@
 
 <% if page.current? %>
   <div class="page current">
-    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm md:btn-md btn-accent" } %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item text-base-content btn btn-sm md:btn-md btn-accent" } %>
   </div>
 <% else %>
   <div class="page">
-    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
+    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item  text-base-content btn btn-sm md:btn-md btn-secondary" } %>
   </div>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <div class="prev">
-  <%= link_to_unless current_page.first?, "«".html_safe, url, {remote: remote, rel: 'prev', class: "join-item btn btn-sm md:btn-md btn-secondary" } %>
+  <%= link_to_unless current_page.first?, "«".html_safe, url, {remote: remote, rel: 'prev', class: "join-item text-base-content btn btn-sm md:btn-md btn-secondary" } %>
 </div>

--- a/app/views/plans/_invitation_url_button.html.erb
+++ b/app/views/plans/_invitation_url_button.html.erb
@@ -5,7 +5,7 @@
       <div data-clipboard-target='link' class="underline">
         <%= @invite_link %>
       </div>
-      <button data-action="clipboard#copyToClipboard" class="btn btn-xs text-xs sm:text-sm">
+      <button data-action="clipboard#copyToClipboard" class="text-base-content btn btn-xs text-xs sm:text-sm">
         リンクをコピーする
       </button>
     </div>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -33,7 +33,7 @@
         </div>
 
         <div class="flex justify-center mt-3">
-          <%= f.submit "次へ", class: "btn btn-sm md:btn-md btn-accent" %>
+          <%= f.submit "次へ", class: "text-base-content btn btn-sm md:btn-md btn-accent" %>
         </div>
       <% end %>
     </div>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -20,6 +20,7 @@
               <th class="md:w-[100px]"></th>
               <th>スポット名</th>
               <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
               <th class="md:w-[100px]">
                 <label>
                   <input type="checkbox" class="checkbox" />
@@ -80,7 +81,7 @@
 
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">
-    <%= link_to "一時保存", plan_path(@plan), class:"btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to "一時保存", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
   
 </article>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -28,7 +28,7 @@
             </tr>
           </thead>
           <tbody id="spot-table">
-            <%= render @spots %>
+            <%= render partial: 'spots/spot', collection: @plan.spots, as: :spot, locals: { plan: @plan } %>
           </tbody>
         </table>
       </div>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -90,8 +90,7 @@
 <script>
   // 他のファイルでも使用できるようにfunctionの外側で定義
   let map
-
-  // 配列にマーカーの情報を追加する
+  
   let markers = [];
 
   // マップの初期化設定
@@ -109,7 +108,8 @@
       (() => {
         let marker = new google.maps.Marker({
           map: map,
-          position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>}
+          position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
+          id: <%= spot.id %>
         });
       })();
     <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -52,6 +52,7 @@
               <th class="md:w-[100px]"></th>
               <th>スポット名</th>
               <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
               <th class="md:w-[100px]">
                 <label>
                   <input type="checkbox" class="checkbox" />
@@ -77,6 +78,7 @@
               <th class="md:w-[100px]"></th>
               <th>スポット名</th>
               <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
               <th class="md:w-[100px]">
                 <label>
                   <input type="checkbox" class="checkbox" />
@@ -112,7 +114,7 @@
 
   <!-- シェアボタン　--> 
   <div class="flex justify-center mt-3">
-    <%= link_to "一覧ページへ戻る", "#", class:"btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to "一覧ページへ戻る", "#", class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>       
   <%= render 'plans/invitation_url_button' %>
 </article>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -123,7 +123,6 @@
   // 他のファイルでも使用できるようにfunctionの外側で定義
   let map
 
-  // 配列にマーカーの情報を追加する
   let markers = [];
 
   // マップの初期化設定
@@ -141,7 +140,8 @@
       (() => {
         let marker = new google.maps.Marker({
           map: map,
-          position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>}
+          position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
+          id: <%= spot.id %>
         });
       })();
     <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -60,7 +60,7 @@
             </tr>
           </thead>
           <tbody id="spot-table">
-            <%= render @spots %>
+            <%= render partial: 'spots/spot', collection: @spots, as: :spot, locals: { plan: @plan } %>
           </tbody>
         </table>
       </div>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
       <%= f.text_field :name, class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
-      <%= f.submit "登録", class:"btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>
+      <%= f.submit "登録", class:"text-base-content btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>
     </div>
   <% end %>
 </div>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,7 +1,20 @@
 <script>
-  // マーカーを作成して配列に追加する
-  markers.push(new google.maps.Marker({
+  // マーカーidをつけて定義
+  const marker = new google.maps.Marker({
     map: map,
-    position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>}
-  }));
+    position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
+    id: <%= @spot.id %>
+  });
+
+  // マーカーを配列に追加
+  markers.push(marker);
+
+  // マーカーを削除
+  function removeMarker(markerId) {
+    const markerIndex = markers.findIndex(marker => marker.id === markerId);
+    if (markerIndex !== -1) {
+      markers[markerIndex].setMap(null); // マーカーをマップから削除
+      markers.splice(markerIndex, 1); // 配列からマーカーを削除
+    }
+  }
 </script>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,13 +1,10 @@
 <script>
-  // マーカーidをつけて定義
-  const marker = new google.maps.Marker({
+  // マーカーにidを付与して、配列に追加
+  markers.push(new google.maps.Marker({
     map: map,
     position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
     id: <%= @spot.id %>
-  });
-
-  // マーカーを配列に追加
-  markers.push(marker);
+  }));
 
   // マーカーを削除
   function removeMarker(markerId) {

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -13,7 +13,7 @@
     <% end %>
   </td>
   <td>
-    <%= link_to "削除", spot_path(spot, plan_id: plan.id), class:"btn btn-accent", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
+      <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"btn btn-accent", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
   </td>
   <th>
     <label>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,8 +12,15 @@
       </div>
     <% end %>
   </td>
-  <td>
-      <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"btn btn-accent", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
+  <td class="hidden md:block">
+    <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
+  </td>
+  <td class="md:hidden">
+    <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } do %>
+      <span class="material-symbols-outlined">
+        delete
+      </span>
+    <% end %>
   </td>
   <th>
     <label>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -13,7 +13,7 @@
     <% end %>
   </td>
   <td>
-    <%= link_to "削除", spot_path(spot), class:"btn btn-accent", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
+    <%= link_to "削除", spot_path(spot, plan_id: plan.id), class:"btn btn-accent", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
   </td>
   <th>
     <label>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,6 +12,9 @@
       </div>
     <% end %>
   </td>
+  <td>
+    <%= link_to "削除", spot_path(spot), class:"btn btn-accent", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
+  </td>
   <th>
     <label>
       <input type="checkbox" class="checkbox" />

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
   <%= turbo_stream.append "spot-table" do %>
-    <%= render "spot", spot: @spot %>
+    <%= render "spot", spot: @spot, plan: @planned_spot.plan %>
   <% end %>
 <% end %>
 <%= turbo_stream.replace "spot-form" do %>

--- a/app/views/spots/destroy.turbo_stream.erb
+++ b/app/views/spots/destroy.turbo_stream.erb
@@ -1,0 +1,4 @@
+
+<%= turbo_stream.remove "spot-#{@spot.id}" do %>
+  <%= render "spot", spot: @spot %>
+<% end %>

--- a/app/views/spots/destroy.turbo_stream.erb
+++ b/app/views/spots/destroy.turbo_stream.erb
@@ -1,4 +1,7 @@
-
+<%= turbo_stream.remove "map-marker-#{@spot.id}" %>
 <%= turbo_stream.remove "spot-#{@spot.id}" do %>
   <%= render "spot", spot: @spot %>
 <% end %>
+<script>
+  removeMarker(<%= @spot.id %>);
+</script>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -4,12 +4,12 @@
   <h1 class="text-3xl underline">
       Hello world!
   </h1>  
-  <button class="btn btn-primary">daisyUI</button>
-  <button class="btn btn-accent">daisyUI</button>
-  <button class="btn btn-secondary">daisyUI</button>
-  <button class="btn btn-info">info</button>
-  <button class="btn btn-error">error</button>
-  <%= link_to 'プラン一覧', plans_path, class: "btn btn-success" %>
-  <%= link_to '地図を見る', new_plan_path, class: "btn btn-warning" %>
-  <%= link_to '会員登録', new_user_registration_path, class: "btn btn-primary" %>
+  <button class="btn btn-primary text-base-content">daisyUI</button>
+  <button class="btn btn-accent text-base-content">daisyUI</button>
+  <button class="btn btn-secondary text-base-content">daisyUI</button>
+  <button class="btn btn-info text-base-content">info</button>
+  <button class="btn btn-error text-base-content">error</button>
+  <%= link_to 'プラン一覧', plans_path, class: "btn btn-success text-base-content" %>
+  <%= link_to '地図を見る', new_plan_path, class: "btn btn-warning text-base-content" %>
+  <%= link_to '会員登録', new_user_registration_path, class: "btn btn-primary text-base-content" %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,6 +22,7 @@ ja:
       added: "%{item}のメンバーに追加されました"
       already_registered_plan: "すでに%{item}のメンバーです"
       invitation_token_invalid: "この招待コードは不正です メンバーにURLの再発行を依頼してください"
+      delete_confirm: 削除しますか？
   plans:
     index:
       title: プラン一覧


### PR DESCRIPTION
### 概要
スポット削除機能の実装

### 実装ページ
- PC画面
![48037a4897f43581da6443018550e9d4](https://github.com/maru973/Tripot_Share/assets/148407473/edd5c59a-42ea-4caa-bbbb-89aa42c3b052)

- スマホ画面
<img width="233" alt="9fe5ed4f700d5ee3c5191e5b7642bf46" src="https://github.com/maru973/Tripot_Share/assets/148407473/024f2e44-504e-4036-9297-efae44bef1d0">



### 内容
- [x] 削除ボタンを押すとスポットがリストから削除される
- [x] PlannedSpotsテーブルから該当データが削除される
- [x] new_spotsページ、showページどちらからでも削除が可能   
- [x] マーカーにIDを付与 


### 補足
マーカーの削除がリロードしないと行われないので、今後修正。
ボタンの文字色をbase-contentに修正。
googleiconsの色もbase-contentと同色に設定。