### PR TITLE
【feature】登録したスポットをそのユーザーに紐付け close #128

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -17,7 +17,7 @@ class SpotsController < ApplicationController
 
       @spot.save
     end
-    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id,)
+    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
     if @planned_spot.new_record?
       @planned_spot.user_id = current_user.id
       @planned_spot.save

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -17,8 +17,9 @@ class SpotsController < ApplicationController
 
       @spot.save
     end
-    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id, user_id: current_user.id)
+    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id,)
     if @planned_spot.new_record?
+      @planned_spot.user_id = current_user.id
       @planned_spot.save
     end
   end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -17,7 +17,7 @@ class SpotsController < ApplicationController
 
       @spot.save
     end
-    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
+    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id, user_id: current_user.id)
     if @planned_spot.new_record?
       @planned_spot.save
     end

--- a/app/models/planned_spot.rb
+++ b/app/models/planned_spot.rb
@@ -1,4 +1,5 @@
 class PlannedSpot < ApplicationRecord
   belongs_to :plan
   belongs_to :spot
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :plans, foreign_key: 'owner_id'
   has_many :members, dependent: :destroy
   has_many :plans, through: :members
+  has_many :planned_spots
 
 
   attr_accessor :plan_id

--- a/db/migrate/20240514015125_add_user_id_to_planned_spots.rb
+++ b/db/migrate/20240514015125_add_user_id_to_planned_spots.rb
@@ -1,5 +1,5 @@
 class AddUserIdToPlannedSpots < ActiveRecord::Migration[7.1]
   def change
-    add_column :planned_spots, :user_id, :integer
+    add_reference :planned_spots, :user, foreign_key: true
   end
 end

--- a/db/migrate/20240514015125_add_user_id_to_planned_spots.rb
+++ b/db/migrate/20240514015125_add_user_id_to_planned_spots.rb
@@ -1,5 +1,5 @@
 class AddUserIdToPlannedSpots < ActiveRecord::Migration[7.1]
   def change
-    add_reference :planned_spots, :user, foreign_key: true
+    add_reference :planned_spots, :user, null: false, foreign_key: true
   end
 end

--- a/db/migrate/20240514015125_add_user_id_to_planned_spots.rb
+++ b/db/migrate/20240514015125_add_user_id_to_planned_spots.rb
@@ -1,0 +1,5 @@
+class AddUserIdToPlannedSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :planned_spots, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_13_014732) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_015125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_014732) do
     t.bigint "spot_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["plan_id"], name: "index_planned_spots_on_plan_id"
     t.index ["spot_id"], name: "index_planned_spots_on_spot_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_015125) do
     t.bigint "spot_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["plan_id"], name: "index_planned_spots_on_plan_id"
     t.index ["spot_id"], name: "index_planned_spots_on_spot_id"
     t.index ["user_id"], name: "index_planned_spots_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,9 +28,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_015125) do
     t.bigint "spot_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["plan_id"], name: "index_planned_spots_on_plan_id"
     t.index ["spot_id"], name: "index_planned_spots_on_spot_id"
+    t.index ["user_id"], name: "index_planned_spots_on_user_id"
   end
 
   create_table "plans", force: :cascade do |t|
@@ -87,5 +88,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_015125) do
   add_foreign_key "members", "users"
   add_foreign_key "planned_spots", "plans"
   add_foreign_key "planned_spots", "spots"
+  add_foreign_key "planned_spots", "users"
   add_foreign_key "plans", "users", column: "owner_id"
 end


### PR DESCRIPTION
### 概要
登録したスポットをそのユーザーに紐付け

### 実際のデータ
<img width="674" alt="1f1e8a502a00d471a7b2ef7e0ec92ed3" src="https://github.com/maru973/Tripot_Share/assets/148407473/0502d92f-0bb5-4bc1-a9da-2bac62ac367d">

### 内容
- [x]  PlannedSpotsテーブルにuser_idのカラム追加
- [x] スポット登録時にPlannedSpotsテーブルにcurrent_userをuser_idに保存
- [x] plan_idとspot_idが同じものは他のユーザーでも登録しない 
