### PR TITLE
【feature】ユーザーごとのタブにそのユーザーが登録したスポットを登録機能の実装 close #78

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -21,6 +21,7 @@ class PlansController < ApplicationController
 
   def new_spots
     @plan = Plan.find(params[:id])
+    @users = @plan.users
     if current_user.member?(@plan.id)
       @spot = Spot.new
       @spots = @plan.spots
@@ -31,6 +32,7 @@ class PlansController < ApplicationController
 
   def show
     @plan = Plan.find(params[:id])
+    @users = @plan.users
     @spots = @plan.spots
     @user = User.new
     @resource_name = @user.class.name.underscore

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -22,6 +22,14 @@ class PlansController < ApplicationController
   def new_spots
     @plan = Plan.find(params[:id])
     @users = @plan.users
+    @user_spots = {}
+
+    # 各ユーザーのスポットをハッシュに入れる
+    @users.each do |user|
+      @user_spots[user.id] = Spot.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, user_id: user.id })
+    end
+
+    # memberのみ編集可
     if current_user.member?(@plan.id)
       @spot = Spot.new
       @spots = @plan.spots
@@ -33,7 +41,12 @@ class PlansController < ApplicationController
   def show
     @plan = Plan.find(params[:id])
     @users = @plan.users
-    @spots = @plan.spots
+    @spots = @plan.spots # マーカーを表示に使用
+    @user_spots = {}
+
+    @users.each do |user|
+      @user_spots[user.id] = Spot.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, user_id: user.id })
+    end
     @user = User.new
     @resource_name = @user.class.name.underscore
     @invite_link = accept_plan_url(invitation_token: @plan.invitation_token) if @plan.invitation_token.present?

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,5 +1,6 @@
 class SpotsController < ApplicationController
   def create
+    @user = current_user
     @spot = Spot.find_or_initialize_by(name: spot_params[:name])
     if @spot.new_record?
       results = Geocoder.search(spot_params[:name])

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -8,5 +8,6 @@ window.Stimulus   = application
 
 export { application }
 
-import { Modal } from "tailwindcss-stimulus-components"
+import { Modal, Tabs } from "tailwindcss-stimulus-components"
 application.register('modal', Modal)
+application.register('tabs', Tabs)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,6 +1,8 @@
 class Spot < ApplicationRecord
   has_many :planned_spots, dependent: :destroy
-  has_many :plans,through: :planned_spots
+  has_many :plans, through: :planned_spots
+  has_many :users, through: :planned_spots
+
 
 
   geocoded_by :address

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   has_many :plans, foreign_key: 'owner_id'
   has_many :members, dependent: :destroy
   has_many :plans, through: :members
-  has_many :planned_spots
-
+  has_many :planned_spots, dependent: :destroy
+  has_many :spots, through: :planned_spots
 
   attr_accessor :plan_id
 

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -1,83 +1,38 @@
-<div class="m-5">
-  <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
-    <div class="flex overflow-x-auto">
-      <div class="flex-none">
-        <ul class="list-reset flex">
-          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">あやか</a>
-          </li>
-          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">さかもとりょうま</a>
-          </li>
-          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Saki</a>
-          </li>
-        </ul>
+<% users.each do |user| %>
+  <div class="m-5">
+    <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
+      <div class="flex overflow-x-auto">
+        <div class="flex-none">
+          <ul class="list-reset flex">
+              <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+                <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
+              </li>
+          </ul>
+        </div>
       </div>
-    </div>
 
-    <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-          </tbody>
-        </table>
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+              <%= render partial: 'spots/spot', spot: spot, plan: plan %>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -1,16 +1,17 @@
-<% users.each do |user| %>
-  <div class="m-5">
-    <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
-      <div class="flex overflow-x-auto">
-        <div class="flex-none">
-          <ul class="list-reset flex">
-              <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-                <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
-              </li>
-          </ul>
-        </div>
+<div class="m-5">
+  <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
+    <div class="flex overflow-x-auto">
+      <div class="flex-none">
+        <ul class="list-reset flex">
+          <% users.each do |user| %>
+            <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+              <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
+            </li>
+          <% end %>
+        </ul>
       </div>
-
+    </div>
+    <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
         <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
           <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
@@ -27,12 +28,14 @@
                 </th>
               </tr>
             </thead>
-            <tbody id="spot-table">
-              <%= render partial: 'spots/spot', spot: spot, plan: plan %>
-            </tbody>
+              <tbody id="spot-table-<%= user.id %>">
+                <% user_spots[user.id].each do |spot| %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan } %>
+                <% end %>
+              </tbody>
           </table>
         </div>
       </div>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -12,83 +12,11 @@
           <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
             <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Saki</a>
           </li>
-          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Matsuda Genta</a>
-          </li>
-          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Matsuda Genta</a>
-          </li>
-          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Matsuda Genta</a>
-          </li>
         </ul>
       </div>
     </div>
 
     <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
       <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
         <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
           <thead>

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -1,0 +1,155 @@
+<div class="m-5">
+  <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
+    <div class="flex overflow-x-auto">
+      <div class="flex-none">
+        <ul class="list-reset flex">
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">あやか</a>
+          </li>
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">さかもとりょうま</a>
+          </li>
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Saki</a>
+          </li>
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Matsuda Genta</a>
+          </li>
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Matsuda Genta</a>
+          </li>
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 font-semibold rounded-t-xl">Matsuda Genta</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">
+                <label>
+                  <input type="checkbox" class="checkbox" />
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="spot-table">
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">
+                <label>
+                  <input type="checkbox" class="checkbox" />
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="spot-table">
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">
+                <label>
+                  <input type="checkbox" class="checkbox" />
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="spot-table">
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">
+                <label>
+                  <input type="checkbox" class="checkbox" />
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="spot-table">
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">
+                <label>
+                  <input type="checkbox" class="checkbox" />
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="spot-table">
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">
+                <label>
+                  <input type="checkbox" class="checkbox" />
+                </label>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="spot-table">
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -38,11 +38,11 @@
                   </th>
                 </tr>
               </thead>
-              <tbody id="spot-table">
-                <% @user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
-                <% end %>
-              </tbody>
+                <tbody id="spot-table-<%= user.id %>">
+                  <% @user_spots[user.id].each do |spot| %>
+                    <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
+                  <% end %>
+                </tbody>
             </table>
           </div>
         </div>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -8,7 +8,7 @@
   <%= render "spots/form", spot: @spot, plan: @plan %>
 
   <!-- 登録済みリスト -->
-  <div class="m-5">
+    <div class="m-5">
     <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
       <div class="flex overflow-x-auto">
         <div class="flex-none">
@@ -21,53 +21,35 @@
           </ul>
         </div>
       </div>
-
-      <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
-        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th class="md:w-[100px]"></th>
-                <th>スポット名</th>
-                <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]">
-                  <label>
-                    <input type="checkbox" class="checkbox" />
-                  </label>
-                </th>
-              </tr>
-            </thead>
-            <tbody id="spot-table">
-              <%= render partial: 'spots/spot', collection: @plan.spots, as: :spot, locals: { plan: @plan } %>
-            </tbody>
-          </table>
+      <% @users.each do |user| %>
+        <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+          <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+            <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+              <thead>
+                <tr>
+                  <th class="md:w-[100px]"></th>
+                  <th>スポット名</th>
+                  <th class="md:w-[100px]">登録者</th>
+                  <th class="md:w-[100px]"></th>
+                  <th class="md:w-[100px]">
+                    <label>
+                      <input type="checkbox" class="checkbox" />
+                    </label>
+                  </th>
+                </tr>
+              </thead>
+              <tbody id="spot-table">
+                <% @user_spots[user.id].each do |spot| %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
-      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th class="md:w-[100px]"></th>
-                <th>スポット名</th>
-                <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]">
-                  <label>
-                    <input type="checkbox" class="checkbox" />
-                  </label>
-                </th>
-              </tr>
-            </thead>
-            <tbody id="spot-table">
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <% end %>
     </div>
   </div>
-  
+
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">
     <%= link_to "一時保存", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -8,8 +8,87 @@
   <%= render "spots/form", spot: @spot, plan: @plan %>
 
   <!-- 登録済みリスト -->
-  <%= render 'list' %>
+  <div class="m-5">
+    <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
+      <div class="flex overflow-x-auto">
+        <div class="flex-none">
+          <ul class="list-reset flex">
+            <% @users.each do |user| %>
+              <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+                <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
 
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+              <%= render partial: 'spots/spot', collection: @plan.spots, as: :spot, locals: { plan: @plan } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">
     <%= link_to "一時保存", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -8,47 +8,7 @@
   <%= render "spots/form", spot: @spot, plan: @plan %>
 
   <!-- 登録済みリスト -->
-    <div class="m-5">
-    <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
-      <div class="flex overflow-x-auto">
-        <div class="flex-none">
-          <ul class="list-reset flex">
-            <% @users.each do |user| %>
-              <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-                <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-      <% @users.each do |user| %>
-        <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
-          <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-            <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-              <thead>
-                <tr>
-                  <th class="md:w-[100px]"></th>
-                  <th>スポット名</th>
-                  <th class="md:w-[100px]">登録者</th>
-                  <th class="md:w-[100px]"></th>
-                  <th class="md:w-[100px]">
-                    <label>
-                      <input type="checkbox" class="checkbox" />
-                    </label>
-                  </th>
-                </tr>
-              </thead>
-                <tbody id="spot-table-<%= user.id %>">
-                  <% @user_spots[user.id].each do |spot| %>
-                    <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
-                  <% end %>
-                </tbody>
-            </table>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan %>
 
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -65,27 +65,6 @@
           </table>
         </div>
       </div>
-      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th class="md:w-[100px]"></th>
-                <th>スポット名</th>
-                <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]">
-                  <label>
-                    <input type="checkbox" class="checkbox" />
-                  </label>
-                </th>
-              </tr>
-            </thead>
-            <tbody id="spot-table">
-            </tbody>
-          </table>
-        </div>
-      </div>
     </div>
   </div>
   

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -8,76 +8,7 @@
   <%= render "spots/form", spot: @spot, plan: @plan %>
 
   <!-- 登録済みリスト -->
-  <div role="tablist" class="tabs tabs-lifted tabs-xs md:tabs-lg mx-auto">
-    <!-- タブ１ -->
-    <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="あやか" checked />
-    <!-- タブの中身 -->
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-4">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-            <%= render partial: 'spots/spot', collection: @plan.spots, as: :spot, locals: { plan: @plan } %>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    
-
-    <!-- タブ２ -->
-    <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="Saki" />
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-4">
-      <div class="overflow-auto h-[400px] w-[360px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-        </table>
-      </div>
-    </div>
-
-    <!-- タブ３ -->
-    <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="Ken" />
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-4">
-      <div class="overflow-auto h-[400px] w-[360px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-        </table>
-      </div>
-    </div>
-  </div>
+  <%= render 'list' %>
 
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -40,47 +40,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <div class="m-5">
-    <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
-      <div class="flex overflow-x-auto">
-        <div class="flex-none">
-          <ul class="list-reset flex">
-            <% @users.each do |user| %>
-              <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-                <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-      <% @users.each do |user| %>
-        <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
-          <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-            <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-              <thead>
-                <tr>
-                  <th class="md:w-[100px]"></th>
-                  <th>スポット名</th>
-                  <th class="md:w-[100px]">登録者</th>
-                  <th class="md:w-[100px]"></th>
-                  <th class="md:w-[100px]">
-                    <label>
-                      <input type="checkbox" class="checkbox" />
-                    </label>
-                  </th>
-                </tr>
-              </thead>
-                <tbody id="spot-table-<%= user.id %>">
-                  <% @user_spots[user.id].each do |spot| %>
-                    <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
-                  <% end %>
-                </tbody>
-            </table>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan %>
 
   <!-- シェアボタン --> 
   <div class="flex justify-center mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -40,7 +40,86 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list' %>
+  <div class="m-5">
+    <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
+      <div class="flex overflow-x-auto">
+        <div class="flex-none">
+          <ul class="list-reset flex">
+            <% @users.each do |user| %>
+              <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+                <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+              <%= render partial: 'spots/spot', collection: @spots, as: :spot, locals: { plan: @plan } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]">
+                  <label>
+                    <input type="checkbox" class="checkbox" />
+                  </label>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="spot-table">
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <!-- シェアボタン　--> 
   <div class="flex justify-center mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -40,77 +40,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <div role="tablist" class="tabs tabs-lifted tabs-xs md:tabs-lg mx-auto mt-3">
-    <!-- タブ１ -->
-    <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="あやか" checked />
-    <!-- タブの中身 -->
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-4">
-      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="spot-table">
-            <%= render partial: 'spots/spot', collection: @spots, as: :spot, locals: { plan: @plan } %>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    
-
-    <!-- タブ２ -->
-    <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="Saki" />
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-4">
-      <div class="overflow-auto h-[400px] w-[360px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-        </table>
-      </div>
-    </div>
-
-    <!-- タブ３ -->
-    <input type="radio" name="my_tabs_2" role="tab" class="tab" aria-label="Ken" />
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-4">
-      <div class="overflow-auto h-[400px] w-[360px] md:w-[1300px] mx-auto">
-        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]">
-                <label>
-                  <input type="checkbox" class="checkbox" />
-                </label>
-              </th>
-            </tr>
-          </thead>
-        </table>
-      </div>
-    </div>
-  </div>
+  <%= render 'list' %>
 
   <!-- シェアボタン　--> 
   <div class="flex justify-center mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -70,11 +70,11 @@
                   </th>
                 </tr>
               </thead>
-              <tbody id="spot-table">
-                <% @user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
-                <% end %>
-              </tbody>
+                <tbody id="spot-table-<%= user.id %>">
+                  <% @user_spots[user.id].each do |spot| %>
+                    <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
+                  <% end %>
+                </tbody>
             </table>
           </div>
         </div>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -53,75 +53,36 @@
           </ul>
         </div>
       </div>
-
-      <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
-        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th class="md:w-[100px]"></th>
-                <th>スポット名</th>
-                <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]">
-                  <label>
-                    <input type="checkbox" class="checkbox" />
-                  </label>
-                </th>
-              </tr>
-            </thead>
-            <tbody id="spot-table">
-              <%= render partial: 'spots/spot', collection: @spots, as: :spot, locals: { plan: @plan } %>
-            </tbody>
-          </table>
+      <% @users.each do |user| %>
+        <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+          <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+            <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+              <thead>
+                <tr>
+                  <th class="md:w-[100px]"></th>
+                  <th>スポット名</th>
+                  <th class="md:w-[100px]">登録者</th>
+                  <th class="md:w-[100px]"></th>
+                  <th class="md:w-[100px]">
+                    <label>
+                      <input type="checkbox" class="checkbox" />
+                    </label>
+                  </th>
+                </tr>
+              </thead>
+              <tbody id="spot-table">
+                <% @user_spots[user.id].each do |spot| %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: @plan } %>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
-      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th class="md:w-[100px]"></th>
-                <th>スポット名</th>
-                <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]">
-                  <label>
-                    <input type="checkbox" class="checkbox" />
-                  </label>
-                </th>
-              </tr>
-            </thead>
-            <tbody id="spot-table">
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div class="hidden py-4 px-4 border bg-base-100 rounded-box" data-tabs-target="panel">
-        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
-          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th class="md:w-[100px]"></th>
-                <th>スポット名</th>
-                <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]">
-                  <label>
-                    <input type="checkbox" class="checkbox" />
-                  </label>
-                </th>
-              </tr>
-            </thead>
-            <tbody id="spot-table">
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <% end %>
     </div>
   </div>
 
-  <!-- シェアボタン　--> 
+  <!-- シェアボタン --> 
   <div class="flex justify-center mt-3">
     <%= link_to "一覧ページへ戻る", "#", class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>       

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
-  <%= turbo_stream.append "spot-table" do %>
+  <%= turbo_stream.append "spot-table-#{@user.id}" do %>
     <%= render "spot", spot: @spot, plan: @planned_spot.plan %>
   <% end %>
 <% end %>


### PR DESCRIPTION
### 概要
ユーザーごとのタブにそのユーザーが登録したスポットを登録機能の実装

### 実装ページ
![0ebe55cf03fd060c2bee896a185825eb](https://github.com/maru973/Tripot_Share/assets/148407473/239e8ed5-0a1f-44d0-a6f2-73e4e251be61)


### 内容
- [x] ユーザーが登録したスポットはそのユーザーのタブ内に表示
- [x] UsersテーブルとSpotsテーブルのアソシエーション設定
- [x] タブ名はユーザー名を使用   
- [x] スポットテーブルをパーシャルファイルに切り出し 

