### PR TITLE
【feature】プラン作成でいきたい県を登録するとスポット登録ページでズームされる close #80

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -5,11 +5,22 @@ class Plan < ApplicationRecord
   has_many :members, dependent: :destroy
   has_many :users, through: :members
 
-  validates :name, presence: true, length: { maximum: 255 }
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :location, presence: true
 
   validate :dates_check
 
-   # トークン生成のためのメソッド
+  JAPAN_PREFECTURES = [ "北海道", "青森県", "岩手県", "宮城県", "秋田県", 
+    "山形県", "福島県", "茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", 
+    "神奈川県", "新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県", "岐阜県", 
+    "静岡県", "愛知県", "三重県", "滋賀県", "京都府", "大阪府", "兵庫県", "奈良県", 
+    "和歌山県", "鳥取県", "島根県", "岡山県", "広島県", "山口県", "徳島県", "香川県", 
+    "愛媛県", "高知県", "福岡県", "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", 
+    "鹿児島県", "沖縄県" 
+  ]
+
+
+  # トークン生成のためのメソッド
   def generate_token
    self.invitation_token = Devise.friendly_token
    save

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -1,8 +1,8 @@
 <div class="card bg-base-100 w-[350px] h-[130px] md:w-[500px] md:h-[300px] shadow-xl overflow-hidden hover:shadow-2xl group rounded-xl transition-all duration-300 transform">
   <%= image_tag "bgcard.jpg", alt: "bg-image", class: "md:block absolute inset-0 h-full w-full object-cover z-0" %>
   <%= image_tag "bgcard-sm.jpg", alt: "bg-image", class: "md:hidden absolute inset-0 h-full w-full object-cover z-0" %>
-  <div class="card-body ms-4 mt-2 md:m-0 md:items-center md:text-center z-10 bg-opacity-0 md:mt-14 md:pt-8">
-    <h2 class="card-title text-base truncate md:text-xl">
+  <div class="card-body ms-4 mt-2 md:items-center md:text-center z-10 bg-opacity-0 md:mt-14 md:pt-8">
+    <h2 class="text-base truncate md:text-2xl">
       <%= plan.name %>
       <%= link_to "#" do %>
         <span class="material-symbols-outlined pt-2 md:pt-3" style= "font-size: 16px;">
@@ -10,21 +10,25 @@
         </span>
       <% end %>
     </h2>
-    <div class="hidden md:block">
-      <div class="flex justify-center">
-        <span class="material-symbols-outlined pt-1" style= "font-size: 20px;">
+    <div class="flex md:flex-col">
+      <div class="flex md:justify-center ps-1 md:ps-0">
+        <span class="material-symbols-outlined md:pt-1" style= "font-size: 18px;">
           location_on
         </span>
-        <%= plan.location %>
+        <div class="text-xs md:text-base">
+          <%= plan.location %>
+        </div>
       </div>
+
+      <% if plan.start_date.present? || plan.end_date.present? %>
+        <p class="text-xs md:text-lg md:pt-2 ms-10 md:ms-0">
+          <%= plan.start_date %>〜<%= plan.end_date %>
+        </p>
+      <% else %>
+        <p class="text-xs md:text-lg md:pt-2 ms-20 md:ms-0"><%= t('defaults.undecided_date') %></p>
+      <% end %>
     </div>
-    <% if plan.start_date.present? || plan.end_date.present? %>
-      <p class="text-xs md:text-lg">
-        <%= plan.start_date %>〜<%= plan.end_date %>
-      </p>
-    <% else %>
-      <p class="text-xs md:text-lg"><%= t('defaults.undecided_date') %></p>
-    <% end %>
+
     <div class="card-actions justify-end md:hidden">
       <%= link_to t('defaults.show'), plan_path(plan), class:"link" %>
     </div>

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -1,7 +1,7 @@
 <div class="card bg-base-100 w-[350px] h-[130px] md:w-[500px] md:h-[300px] shadow-xl overflow-hidden hover:shadow-2xl group rounded-xl transition-all duration-300 transform">
   <%= image_tag "bgcard.jpg", alt: "bg-image", class: "md:block absolute inset-0 h-full w-full object-cover z-0" %>
   <%= image_tag "bgcard-sm.jpg", alt: "bg-image", class: "md:hidden absolute inset-0 h-full w-full object-cover z-0" %>
-  <div class="card-body ms-4 mt-2 md:m-0 md:items-center md:text-center z-10 bg-opacity-0 md:pt-28">
+  <div class="card-body ms-4 mt-2 md:m-0 md:items-center md:text-center z-10 bg-opacity-0 md:mt-14 md:pt-8">
     <h2 class="card-title text-base truncate md:text-xl">
       <%= plan.name %>
       <%= link_to "#" do %>
@@ -10,6 +10,14 @@
         </span>
       <% end %>
     </h2>
+    <div class="hidden md:block">
+      <div class="flex justify-center">
+        <span class="material-symbols-outlined pt-1" style= "font-size: 20px;">
+          location_on
+        </span>
+        <%= plan.location %>
+      </div>
+    </div>
     <% if plan.start_date.present? || plan.end_date.present? %>
       <p class="text-xs md:text-lg">
         <%= plan.start_date %>〜<%= plan.end_date %>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -11,10 +11,10 @@
           <%= f.text_field :name, autofocus: true, class: "input input-sm md:input-md input-bordered", placeholder: "例：卒業旅行 in 京都" %>
         </div>
 
-        <!--<div class="form-control my-3">
-          <%= f.label :address, "旅行する都道府県" %>
-          <%= f.text_field :address, autofocus: true, class: "input input-sm md:input-md input-bordered", placeholder: "旅行する都道府県を入力してね" %>
-        </div>-->
+        <div class="form-control my-3">
+          <%= f.label :location, "旅行する場所" %>
+          <%= f.text_field :location, autofocus: true, class: "input input-sm md:input-md input-bordered", placeholder: "旅行する都道府県を入力してね" %>
+        </div>
 
         <div class="form-control my-3">
           <div class="flex">

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -12,8 +12,8 @@
         </div>
 
         <div class="form-control my-3">
-          <%= f.label :location, "旅行する場所" %>
-          <%= f.text_field :location, autofocus: true, class: "input input-sm md:input-md input-bordered", placeholder: "旅行する都道府県を入力してね" %>
+          <%= f.label :location %>
+          <%= f.select :location, options_for_select(Plan::JAPAN_PREFECTURES), include_blank: "", class: "select select-sm md:select-md select-bordered" %>
         </div>
 
         <div class="form-control my-3">

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -28,8 +28,8 @@
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {
-      zoom: 5,
-      center:  { lat: 37.148, lng: 138.234 }, // 地図の中心を指定
+      zoom: 10,
+      center:  { lat: <%= @location.latitude %>, lng: <%= @location.longitude %> }, // 地図の中心を指定
       // ストリートビューなど地図右下に表示されていたオプションを削除
       disableDefaultUI: true,
       keyboardShortcuts: false

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -60,8 +60,8 @@
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {
-      zoom: 5,
-      center:  { lat: 37.148, lng: 138.234 }, // 地図の中心を指定
+      zoom: 10,
+      center:  { lat: <%= @location.latitude %>, lng: <%= @location.longitude %> }, // 地図の中心を指定
       // ストリートビューなど地図右下に表示されていたオプションを削除
       disableDefaultUI: true,
       keyboardShortcuts: false

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,6 +8,7 @@ ja:
         name: プラン名
         start_date: 旅行開始日
         end_date: 旅行終了日
+        location: 旅行先の都道府県名
       spot:
         name: スポット名
         address: 住所

--- a/db/migrate/20240515062628_add_location_to_plans.rb
+++ b/db/migrate/20240515062628_add_location_to_plans.rb
@@ -1,0 +1,8 @@
+class AddLocationToPlans < ActiveRecord::Migration[7.1]
+  def change
+    add_column :plans, :location, :string, null: false
+    add_column :plans, :address, :string, null: false
+    add_column :plans, :latitude, :float, null: false
+    add_column :plans, :longitude, :float, null: false
+  end
+end

--- a/db/migrate/20240515062628_add_location_to_plans.rb
+++ b/db/migrate/20240515062628_add_location_to_plans.rb
@@ -1,8 +1,5 @@
 class AddLocationToPlans < ActiveRecord::Migration[7.1]
   def change
     add_column :plans, :location, :string, null: false
-    add_column :plans, :address, :string, null: false
-    add_column :plans, :latitude, :float, null: false
-    add_column :plans, :longitude, :float, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_015125) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_15_062628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_015125) do
     t.datetime "updated_at", null: false
     t.integer "owner_id", null: false
     t.string "invitation_token"
+    t.string "location", null: false
+    t.string "address", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
     t.index ["invitation_token"], name: "index_plans_on_invitation_token", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,9 +43,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_062628) do
     t.integer "owner_id", null: false
     t.string "invitation_token"
     t.string "location", null: false
-    t.string "address", null: false
-    t.float "latitude", null: false
-    t.float "longitude", null: false
     t.index ["invitation_token"], name: "index_plans_on_invitation_token", unique: true
   end
 


### PR DESCRIPTION
### 概要
プラン作成でいきたい県を登録するとスポット登録ページでズームされる

### 実装ページ
<img width="1437" alt="2c75e3e61b32ccf28818e01b5d88e7ea" src="https://github.com/maru973/Tripot_Share/assets/148407473/292190ce-4c0a-4795-840d-3bacc3c03e93">

![deba251f71c89480d27cf34a92ef210e](https://github.com/maru973/Tripot_Share/assets/148407473/93c96361-ce0c-45c0-ae08-be2e5a850aa1)

### 内容
- [x] plansテーブルにlocationカラムを追加
- [x] locationが入力されたらその情報を元にSpotsテーブルから緯度経度を探す
- [x] 検索した緯度経度をもとに地図の初期値を設定
- [x] 地図のズームを５から１０に変更
- [x] プラン作成ページにlocation選択フォームを追加
- [x] locationの選択肢はモデルに記載
- [x] プランの一覧ページにあるカードにlocationを追加 


### 補足
選択フォームのデザインが反映されない現象は今後確認していきたい。