### PR TITLE
【feature】planの削除機能実装 close #79

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -76,6 +76,16 @@ class PlansController < ApplicationController
     end
   end
 
+  def destroy
+    @plan = current_user.plans.find(params[:id])
+    if current_user.id === @plan.owner_id
+      @plan.destroy!
+      redirect_to plans_path, status: :see_other, notice: "プランが削除されました"
+    else
+      redirect_to plans_path, alert: "あなたはこのプランのオーナーではないため削除できません"
+    end
+  end
+
   def invitation
     @plan = Plan.find(params[:id])
     @plan.generate_token

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -42,10 +42,18 @@
   <!-- 登録済みリスト -->
   <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan %>
 
-  <!-- シェアボタン --> 
-  <div class="flex justify-center mt-3">
+  <!-- 削除ボタン -->
+  <div class="flex justify-around mt-3">
+    <% if current_user.id === @plan.owner_id %>
+      <%= link_to "削除", @plans_path, class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
+    <% end %>
+
+    <!-- 一覧ページボタン --> 
     <%= link_to "一覧ページへ戻る", plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
-  </div>       
+  </div>
+
+  
+
   <%= render 'plans/invitation_url_button' %>
 </article>
 


### PR DESCRIPTION
### 概要
planの削除機能実装

### 実装ページ
![3f6ce0709ee779da91324d25cd3cd3f4](https://github.com/maru973/Tripot_Share/assets/148407473/af4d57dc-e08d-45a1-8f9a-764e7bb98654)


### 内容
- [x] showページでのみ削除が可能
- [x] そのプランのownerのみ削除ボタンが表示
- [x] 削除後は一覧ページに遷移   


### 補足
プランの削除間違えを防ぐため、削除ボタンは一覧ページにつけずshowページにのみ実装。