### PR TITLE
【feature】マイプランページの実装 close #139

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,5 @@
+class MypagesController < ApplicationController
+  def myplans
+    @plans = current_user.plans.page(params[:page])
+  end
+end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,5 @@
 class MypagesController < ApplicationController
   def myplans
-    @plans = current_user.plans.page(params[:page])
+    @plans = current_user.plans.order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,6 +1,6 @@
 class PlansController < ApplicationController
   def index
-    @plans = current_user.plans.page(params[:page])
+    @plans = Plan.includes(:owner).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/helpers/mypages_helper.rb
+++ b/app/helpers/mypages_helper.rb
@@ -1,0 +1,2 @@
+module MypagesHelper
+end

--- a/app/views/mypages/myplans.html.erb
+++ b/app/views/mypages/myplans.html.erb
@@ -1,0 +1,13 @@
+<article>
+  <div class="grid justify-center items-center">
+    <h2 class="text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center"><%= t('.title') %></h2>
+    <% if @plans.present? %>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-10 mt-3">
+        <%= render @plans %>
+      </div>
+    <% else %>
+      <%= t('.no_result') %>
+    <% end %>
+  </div>
+  <%= paginate @plans %>
+</article>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -29,7 +29,7 @@
           </div>
           <ul tabindex="0" class="border dropdown-content z-[1] menu mt-2 md:mt-4 shadow bg-base-100 rounded-box w-40 md:w-52">
             <li class="md:hidden"><%= link_to "プラン計画", new_plan_path %></li>
-            <li><%= link_to "マイプラン", "#" %></li>
+            <li><%= link_to "マイプラン", myplans_path %></li>
             <li class="md:hidden"><%= link_to "皆のプラン", plans_path %></li>
             <li><%= link_to "マイページ", "#" %></li>
             <li><%= link_to "ログアウト", destroy_user_session_path, data: {turbo_method: :delete} %></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,10 +25,13 @@ ja:
       delete_confirm: 削除しますか？
   plans:
     index:
-      title: プラン一覧
+      title: みんなのプラン
       no_result: プランがありません
     new:
       title: プラン作成
       null_permission: (未定の場合は空欄可)
     new_spots:
       title: スポット登録
+  mypages:
+    myplans: 
+      title: マイプラン

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,10 @@ Rails.application.routes.draw do
 
 
   resources :courses
-  resources :spots, only: %i[create destroy]
+  resource :spots, only: %i[create destroy]
 
-  namespace :mypage do
-    resources :plans, only: [:index]
-    resources :courses, only: [:index]
-    resource :settings, only: %i[show update destroy]
-  end
+  resource :mypage, only: %i[show edit destroy]
+  get 'myplans', to: 'mypages#myplans'
+  get 'mycourses', to: 'mypages#mycourses'
+
 end


### PR DESCRIPTION
### 概要
マイプランページの実装

### 実装ページ
- マイプランページ
<img width="1438" alt="a060953e605e5eb1576760cc92449e66" src="https://github.com/maru973/Tripot_Share/assets/148407473/f237b046-2f18-45e3-ad61-a563b55e305c">

- 一覧ページ
<img width="1435" alt="a3cbb554ae9554c4c941ca924dd3234c" src="https://github.com/maru973/Tripot_Share/assets/148407473/e9b51ec2-4150-40cb-b993-f3066998e48a">



### 内容
- [x] マイページコントローラーの作成
- [x] マイプランのビュー作成 
- [x] マイページ関連のルート変更
- [x] ヘッダーのマイプランのリンクにパスを設定 
- [x] 一覧ページは他のユーザーのプランも表示   


### 補足
マイプランも一覧ページも作成順で表示するように設定し、プランの変更がされても並び順が変わらないようにした。