### PR TITLE
【feature】プラン編集画面に戻るボタンの設置 close #141

### DIFF
--- a/app/views/plans/_edit_form.html.erb
+++ b/app/views/plans/_edit_form.html.erb
@@ -22,7 +22,8 @@
             <%= f.date_field :end_date, class: "input input-xs md:input-sm input-bordered" %>
           </p>
       </div>
-      <div class="md:mt-3">
+      <div class="flex justify-center gap-3 mt-1 md:mt-3 md:mr-4">
+        <%= link_to '戻る', plans_path, class: "text-base-content btn btn-xs md:btn-sm btn-error" %>
         <%= f.submit "更新", class: "text-base-content btn btn-xs md:btn-sm btn-secondary" %>
       </div>
     <% end %>


### PR DESCRIPTION
### 概要
プラン編集画面に戻るボタンの設置

### 実装ページ
![842cd098c5313d9956869fa8f11ebd08](https://github.com/maru973/Tripot_Share/assets/148407473/66838ee2-7dbf-4944-aab4-437b450cacdb)


### 内容
- [x] 編集画面で戻るボタンを押すと編集画面が閉じて元のプランカードに戻る 
