### PR TITLE
【feature】マーカーに画像を挿入 close #19

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,3 +5,9 @@
 .material-symbols-outlined {
   text-color: #592926;
 }
+
+.glyph-img {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%; 
+}

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -22,7 +22,7 @@
 <script>
   // 他のファイルでも使用できるようにfunctionの外側で定義
   let map
-  
+
   let markers = [];
 
   // マップの初期化設定
@@ -32,27 +32,37 @@
       center:  { lat: <%= @location.latitude %>, lng: <%= @location.longitude %> }, // 地図の中心を指定
       // ストリートビューなど地図右下に表示されていたオプションを削除
       disableDefaultUI: true,
-      keyboardShortcuts: false
+      keyboardShortcuts: false,
+      mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
+
     
+
+
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>
       (() => {
-        let marker = new google.maps.Marker({
+        let glyphImg = document.createElement("img");
+
+        glyphImg.src = '<%= asset_path('sample.jpg') %>';
+        glyphImg.className = 'glyph-img';    
+
+        let glyphSvgPinView = new google.maps.marker.PinElement({
+          glyph: glyphImg,
+          
+        });
+
+        let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
           id: <%= spot.id %>,
-          icon: {
-		        url: '<%= asset_path('sample.jpg') %>',
-		        scaledSize: new google.maps.Size(40, 40)
-	        },
-          optimized: false
+          content: glyphSvgPinView.element,
         });
       })();
     <% end %>
-  } 
+  }
 
 </script>
 <!-- google mapのスクリプト -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly" defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly&libraries=marker" defer></script>
 

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -41,7 +41,12 @@
         let marker = new google.maps.Marker({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
-          id: <%= spot.id %>
+          id: <%= spot.id %>,
+          icon: {
+		        url: '<%= asset_path('sample.jpg') %>',
+		        scaledSize: new google.maps.Size(40, 40)
+	        },
+          optimized: false
         });
       })();
     <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -72,21 +72,39 @@
       center:  { lat: <%= @location.latitude %>, lng: <%= @location.longitude %> }, // 地図の中心を指定
       // ストリートビューなど地図右下に表示されていたオプションを削除
       disableDefaultUI: true,
-      keyboardShortcuts: false
+      keyboardShortcuts: false,
+      mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
+
     
+
+
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>
       (() => {
-        let marker = new google.maps.Marker({
+        let glyphImg = document.createElement("img");
+
+        glyphImg.src = '<%= asset_path('sample.jpg') %>';
+        glyphImg.className = 'glyph-img';    
+
+        let glyphSvgPinView = new google.maps.marker.PinElement({
+          glyph: glyphImg,
+          
+        });
+
+        let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
-          id: <%= spot.id %>
+          id: <%= spot.id %>,
+          content: glyphSvgPinView.element,
         });
       })();
     <% end %>
-  } 
+  }
 
 </script>
 <!-- google mapのスクリプト -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly" defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly&libraries=marker" defer></script>
+<style>
+
+</style>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,10 +1,23 @@
 <script>
   // マーカーにidを付与して、配列に追加
-  markers.push(new google.maps.Marker({
-    map: map,
-    position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
-    id: <%= @spot.id %>
-  }));
+  (() => {
+        let glyphImg = document.createElement("img");
+
+        glyphImg.src = '<%= asset_path('sample.jpg') %>';
+        glyphImg.className = 'glyph-img';    
+
+        let glyphSvgPinView = new google.maps.marker.PinElement({
+          glyph: glyphImg,
+          
+        });
+
+        let marker = new google.maps.marker.AdvancedMarkerElement({
+          map: map,
+          position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
+          id: <%= @spot.id %>,
+          content: glyphSvgPinView.element,
+        });
+      })();
 
   // マーカーを削除
   function removeMarker(markerId) {


### PR DESCRIPTION
### 概要
マーカーに画像を挿入

### 実装ページ
![f582b39ef5896e1d517ae498a0fcae9a](https://github.com/maru973/Tripot_Share/assets/148407473/dddd96ac-9e0e-4f95-a5d6-cef8988ab96a)

<img width="101" alt="954331b0b3581148df2dec744dd7473b" src="https://github.com/maru973/Tripot_Share/assets/148407473/05f606c0-6b56-478c-9838-e2040ee62106">


### 内容
- [x] マーカーに画像を追加

### 補足
当初はマーカーの色を変える予定だったが、ユーザーごとのアバターを挿入した方が判別がしやすいと思い、今回の実装に至った。