### PR TITLE
【feature】アバターの追加 close #28

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,6 @@ gem 'kaminari'
 gem 'rails-i18n'
 gem 'devise_invitable'
 gem 'google_places'
+gem 'carrierwave'
 
 gem "dockerfile-rails", ">= 1.6", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,13 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     childprocess (5.0.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -118,6 +125,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.16.3)
     geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -130,6 +138,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -173,6 +184,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
@@ -276,6 +288,8 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -286,6 +300,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -319,6 +334,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  carrierwave
   cssbundling-rails
   debug
   devise

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # 新規登録時(sign_up時)にnameというキーのパラメーターの追加を許可
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :plan_id])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :plan_id, :avatar, :avatar_cache])
     devise_parameter_sanitizer.permit(:invite) { |u| u.permit(:email, :name, :plan_id) }
     devise_parameter_sanitizer.permit(:accept_invitation) { |u| u.permit(:password, :password_confirmation, :invitation_token, :name, :plan_id) }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_many :planned_spots, dependent: :destroy
   has_many :spots, through: :planned_spots
 
+  mount_uploader :avatar, AvatarUploader
+
   attr_accessor :plan_id
 
   # Include default devise modules. Others available are:

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -19,9 +19,12 @@ class AvatarUploader < CarrierWave::Uploader::Base
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
-  def default_url
-    'sample.jpg'
-  end
+
+
+  def default_url(*args)
+    #   For Rails 3.1+ asset pipeline compatibility:
+      ActionController::Base.helpers.asset_path( [version_name, "sample.jpg"].compact.join('_'))
+    end
 
   # Process files as they are uploaded:
   # process scale: [200, 300]
@@ -38,7 +41,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w(jpg jpeg gif png)
+    %w(jpg jpeg png)
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,49 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url
+    'sample.jpg'
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -36,7 +36,7 @@
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
 
-    
+    const baseUrl = '<%= request.base_url %>';
 
 
     // ページリロードしても登録したマーカーが消えない設定
@@ -44,7 +44,12 @@
       (() => {
         let glyphImg = document.createElement("img");
 
-        glyphImg.src = '<%= asset_path('sample.jpg') %>';
+        // CarrierWave URLを絶対URLに変換
+        const avatarUrl = '<%= current_user.avatar_url %>'.startsWith('http')
+          ? '<%= current_user.avatar_url %>'
+          : new URL('<%= current_user.avatar_url %>', baseUrl).href;
+
+        glyphImg.src = avatarUrl;
         glyphImg.className = 'glyph-img';    
 
         let glyphSvgPinView = new google.maps.marker.PinElement({

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -76,7 +76,7 @@
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
 
-    
+    const baseUrl = '<%= request.base_url %>';
 
 
     // ページリロードしても登録したマーカーが消えない設定
@@ -84,7 +84,12 @@
       (() => {
         let glyphImg = document.createElement("img");
 
-        glyphImg.src = '<%= asset_path('sample.jpg') %>';
+        // CarrierWave URLを絶対URLに変換
+        const avatarUrl = '<%= current_user.avatar_url %>'.startsWith('http')
+          ? '<%= current_user.avatar_url %>'
+          : new URL('<%= current_user.avatar_url %>', baseUrl).href;
+
+        glyphImg.src = avatarUrl;
         glyphImg.className = 'glyph-img';    
 
         let glyphSvgPinView = new google.maps.marker.PinElement({

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,6 +28,16 @@
 
           </div>
           <ul tabindex="0" class="border dropdown-content z-[1] menu mt-2 md:mt-4 shadow bg-base-100 rounded-box w-40 md:w-52">
+            <li class="no-hover">
+              <div class="flex">
+                <div class="avatar">
+                  <div class="w-7 h-7 mr-1 rounded-full">
+                    <%= image_tag current_user.avatar_url %>
+                  </div>
+                </div>
+                <%= current_user.name %>
+              </div>
+            </li>
             <li class="md:hidden"><%= link_to "プラン計画", new_plan_path %></li>
             <li><%= link_to "マイプラン", myplans_path %></li>
             <li class="md:hidden"><%= link_to "皆のプラン", plans_path %></li>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,9 +1,18 @@
 <script>
-  // マーカーにidを付与して、配列に追加
-  (() => {
+    const baseUrl = '<%= request.base_url %>';
+
+
+    // ページリロードしても登録したマーカーが消えない設定
+
+      (() => {
         let glyphImg = document.createElement("img");
 
-        glyphImg.src = '<%= asset_path('sample.jpg') %>';
+        // CarrierWave URLを絶対URLに変換
+        const avatarUrl = '<%= current_user.avatar_url %>'.startsWith('http')
+          ? '<%= current_user.avatar_url %>'
+          : new URL('<%= current_user.avatar_url %>', baseUrl).href;
+
+        glyphImg.src = avatarUrl;
         glyphImg.className = 'glyph-img';    
 
         let glyphSvgPinView = new google.maps.marker.PinElement({
@@ -18,6 +27,7 @@
           content: glyphSvgPinView.element,
         });
       })();
+
 
   // マーカーを削除
   function removeMarker(markerId) {

--- a/db/migrate/20240516132128_add_avatar_to_users.rb
+++ b/db/migrate/20240516132128_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_15_062628) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_16_132128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_15_062628) do
     t.string "uid"
     t.string "name", default: "", null: false
     t.integer "invited_plan_id"
+    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"


### PR DESCRIPTION
### 概要
アバターの追加

### 実装ページ
<img width="229" alt="11e164780683762ecc0b2d2736af6264" src="https://github.com/maru973/Tripot_Share/assets/148407473/ccea6d22-504f-4e5c-bbc1-777d814bd962">


### 内容
- [x] Usersテーブルにアバターカラムの追加
- [x] carrierwaveの導入
- [x] デフォルト画像を相対パスで設定
- [x]  ヘッダーにユーザー名とアバターの追加
- [x] JSでアバターURLの絶対パスを取得しマーカーの画像として追加 


### 補足
新規登録時のアバター登録フォームはマイページ作成の時に実装。
マーカーの画像が暫定でcurrent_userのものになっている。