### PR TITLE
1台のVMが常時起動状態になるようにfly.tomlを変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ console_command = '/rails/bin/rails console'
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [checks]


### PR DESCRIPTION
### 概要
1台のVMが常時起動状態になるようにfly.tomlを変更


### 補足
VMが2つあるが、現在の状態だとどちらも停止してしまうのでアプリを開くのに時間がかかるため、変更して常時起動できるようにする。