### PR TITLE
【fix】プラン削除ボタンの文言修正 close #152

### DIFF
--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -45,11 +45,11 @@
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">
     <% if current_user.id === @plan.owner_id %>
-      <%= link_to "削除", @plans_path, class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
+      <%= link_to t('.destroy'), @plans_path, class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
     <% end %>
 
     <!-- 一覧ページボタン --> 
-    <%= link_to "一覧ページへ戻る", plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to t('.back_index'), plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 
   

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -32,6 +32,9 @@ ja:
       null_permission: (未定の場合は空欄可)
     new_spots:
       title: スポット登録
+    show:
+      destroy: プランの削除
+      back_index: みんなのプランへ戻る
   mypages:
     myplans: 
       title: マイプラン


### PR DESCRIPTION
### 概要
プラン削除ボタンの文言修正

### 内容
- [x] ボタンの文言を「削除」から「プランの削除」に変更 
