### PR TITLE
【bug】新規ユーザーに招待メールが送信できないエラーの解消 close #153

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
     # 新規登録時(sign_up時)にnameというキーのパラメーターの追加を許可
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :plan_id, :avatar, :avatar_cache])
     devise_parameter_sanitizer.permit(:invite) { |u| u.permit(:email, :name, :plan_id) }
-    devise_parameter_sanitizer.permit(:accept_invitation) { |u| u.permit(:password, :password_confirmation, :invitation_token, :name, :plan_id) }
+    devise_parameter_sanitizer.permit(:accept_invitation) { |u| u.permit(:password, :password_confirmation, :invitation_token, :name, :plan_id, :email) }
   end
 end

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -1,9 +1,4 @@
 class Users::InvitationsController < Devise::InvitationsController
-  def new
-    @plan = Plan.find(params[:id])
-    super
-  end
-
   def create
     self.resource = resource_class.new
     user_email = params[:user][:email]

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -1,9 +1,15 @@
 class Users::InvitationsController < Devise::InvitationsController
+  def new
+    @plan = Plan.find(params[:id])
+    super
+  end
+
   def create
+    self.resource = resource_class.new
     user_email = params[:user][:email]
     plan_id = params[:user][:plan_id]
 
-     # 既存ユーザーの処理
+    # 既存ユーザーの処理
     if User.find_by(email: user_email.downcase).present?
       user_id = User.find_by(email: user_email.downcase).id
       user = User.find(user_id)
@@ -18,11 +24,11 @@ class Users::InvitationsController < Devise::InvitationsController
         user.save
         redirect_to plan_path(plan_id), notice: t('devise.invitations.send_instructions', email: user_email)
       end
-    elsif User.invite!(email: user_email, invited_plan_id: plan_id).valid? # 新規ユーザーの処理
+    elsif User.invite!(email: user_email, invited_plan_id: plan_id, name: "仮ユーザー名").valid? # 新規ユーザーの処理
       redirect_to plan_path(plan_id), notice: t('devise.invitations.send_instructions', email: user_email)
     else
       flash[:notice] = t('devise.invitations.failure')
-      render 'new', locals: { plan: plan_id }
+      render 'new', locals: { id: plan_id }
     end
   end
 
@@ -31,13 +37,13 @@ class Users::InvitationsController < Devise::InvitationsController
     self.resource = accept_resource
     invitation_accepted = resource.errors.empty?
 
-    user_id = resource.id
-    user = User.find(user_id)
-    Member.create(user_id: user_id, plan_id: user.invited_plan_id)
     yield resource if block_given?
-
+    
     if invitation_accepted
       if resource.class.allow_insecure_sign_in_after_accept
+        user_id = resource.id
+        user = User.find(user_id)
+        Member.create(user_id: user_id, plan_id: user.invited_plan_id)
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message :notice, flash_message if is_flashing_format?
         resource.after_database_authentication
@@ -49,7 +55,7 @@ class Users::InvitationsController < Devise::InvitationsController
       end
     else
       resource.invitation_token = raw_invitation_token
-      respond_with_navigational(resource) { render :edit, status: :unprocessable_entity }
+      respond_with resource { render :edit, status: :unprocessable_entity }
     end
   end
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -9,7 +9,7 @@
         </button>
       </div>
       <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= t "devise.invitations.new.header" %></h2>
-      <%= form_for(resource, as: resource_name, url: user_invitation_path, html: { method: :post }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <% resource.class.invite_key_fields.each do |field| -%>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -9,10 +9,10 @@
         </button>
       </div>
       <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= t "devise.invitations.new.header" %></h2>
-      <%= form_for(@user, as: @resource_name, url: user_invitation_path, html: { method: :post }) do |f| %>
-        <%= render "devise/shared/error_messages", resource: @user %>
+      <%= form_for(resource, as: resource_name, url: user_invitation_path, html: { method: :post }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-        <% @user.class.invite_key_fields.each do |field| -%>
+        <% resource.class.invite_key_fields.each do |field| -%>
           <% f.label field, class:"text-md" %>
           <p class="text-xs md:text-sm text-center">招待メールを送る場合は下記フォームに<br />招待したいメンバーのメールアドレスを<br class="md:hidden" />入力してください</p>
           <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -22,7 +22,7 @@
 
           <li class="text-xs md:text-lg">
             <div data-controller="modal">
-              <%= render template: 'devise/invitations/new' %>
+              <%= render template: 'devise/invitations/new', locals: { resource: @user, resource_name: @resource_name } %>
               <%= link_to new_user_invitation_path(id: @plan.id), data: { action: "click->modal#open", turbo_frame: "modal" } do %>
                 <span class= "material-symbols-outlined" style= "font-size: 20px;">
                   person_add

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,15 +78,4 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-   address:              'smtp.gmail.com',
-   port:                  587,
-   domain:               'tripot-share.fly.dev',
-   user_name:            ENV['GMAIL_USERNAME'],
-   password:             ENV['GMAIL_PASSWORD'],
-   authentication:       'plain',
-   enable_starttls_auto:  true
-  }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,15 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+   address:              'smtp.gmail.com',
+   port:                  587,
+   domain:               'tripot-share.fly.dev',
+   user_name:            ENV['GMAIL_USERNAME'],
+   password:             ENV['GMAIL_PASSWORD'],
+   authentication:       'plain',
+   enable_starttls_auto:  true
+  }
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,11 +74,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_132128) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.integer "invited_plan_id"
+    t.string "avatar"
     t.string "provider"
     t.string "uid"
     t.string "name", default: "", null: false
-    t.integer "invited_plan_id"
-    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"


### PR DESCRIPTION
### 概要
新規ユーザーに招待メールが送信できないエラーの解消

### 内容
- [x] 新規ユーザーに招待メールを送信するとき、nameを「仮ユーザー名」で登録
- [x]  招待された新規ユーザーが会員登録をしてからメンバーテーブルでプランとの紐付けを行う
- [x]  招待された新規ユーザーの会員登録画面でバリデーションエラーのメッセージを表示


### 補足
バリデーションエラー回避のため、新規ユーザーを招待するときにnameに仮名を設定した。
app/views/devise/invitations/new.html.erbは変数をplans/show.html.erbなどで渡すようにしたため、初期のresourceに修正した。