### PR TITLE
【bug】エラーメッセージが出た時のフォームのレイアウト崩れ修正 close #87

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -11,3 +11,7 @@
   height: 30px;
   border-radius: 50%; 
 }
+
+.field_with_errors {
+  display: contents;
+}


### PR DESCRIPTION
### 概要
エラーメッセージが出た時のフォームのレイアウト崩れ修正

### 実装ページ
<img width="473" alt="dc76e25dc281306f77ce6e6f91bf3f86" src="https://github.com/maru973/Tripot_Share/assets/148407473/2221a09a-c4ff-49ec-bcbc-77f44fb9e8da">


### 内容
- [x]  field_with_errorsクラスにdisplay: contents;を設定して、フォームの幅が狭くならないように設定

### 補足
エラーメッセージが出ると該当のフォームが<div class="field_with_errors">で囲われ、それによってフォームの幅が狭くなっていた。
display: contents;を設定することで子要素のスタイルのみ反映するようにした。