### PR TITLE
【bug】フラッシュメッセージがページをリロードしなくても表示される close #113

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,27 +1,38 @@
 class SpotsController < ApplicationController
   def create
     @user = current_user
-    @spot = Spot.find_or_initialize_by(name: spot_params[:name])
-    if @spot.new_record?
-      results = Geocoder.search(spot_params[:name])
-      @latlng = results.first.coordinates
-      @spot.latitude = @latlng[0]
-      @spot.longitude = @latlng[1]
-      @spot.address = results.first.address
-      
-      spot_details = @spot.get_spot_details(spot_params[:name])
-      if spot_details
-        @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
-        @spot.website = spot_details[:website]
-        @spot.phone_number = spot_details[:phone_number]
-      end
 
-      @spot.save
-    end
-    @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
-    if @planned_spot.new_record?
-      @planned_spot.user_id = current_user.id
-      @planned_spot.save
+    respond_to do |format|
+      if spot_params[:name].blank?
+        format.turbo_stream do
+          flash.now[:alert] = 'スポット名を入力してください'
+          render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash_message")
+        end
+      else
+        @spot = Spot.find_or_initialize_by(name: spot_params[:name])
+        if @spot.new_record?
+          results = Geocoder.search(spot_params[:name])
+          @latlng = results.first.coordinates
+          @spot.latitude = @latlng[0]
+          @spot.longitude = @latlng[1]
+          @spot.address = results.first.address
+
+          spot_details = @spot.get_spot_details(spot_params[:name])
+          if spot_details
+            @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+            @spot.website = spot_details[:website]
+            @spot.phone_number = spot_details[:phone_number]
+          end
+
+          @spot.save
+        end
+        @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
+        if @planned_spot.new_record?
+          @planned_spot.user_id = current_user.id
+          @planned_spot.save
+        end
+        format.turbo_stream { flash.now[:notice] = "スポットを登録しました" }
+      end
     end
   end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -30,8 +30,9 @@ class SpotsController < ApplicationController
         if @planned_spot.new_record?
           @planned_spot.user_id = current_user.id
           @planned_spot.save
+          format.turbo_stream { flash.now[:notice] = "スポットを登録しました" }
         end
-        format.turbo_stream { flash.now[:notice] = "スポットを登録しました" }
+        format.turbo_stream { flash.now[:alert] = "そのスポットはすでにプランに登録されています" }
       end
     end
   end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -6,7 +6,7 @@ class SpotsController < ApplicationController
       if spot_params[:name].blank?
         format.turbo_stream do
           flash.now[:alert] = 'スポット名を入力してください'
-          render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash_message")
+          render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
         end
       else
         @spot = Spot.find_or_initialize_by(name: spot_params[:name])

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -4,26 +4,37 @@ class Users::InvitationsController < Devise::InvitationsController
     user_email = params[:user][:email]
     plan_id = params[:user][:plan_id]
 
-    # 既存ユーザーの処理
-    if User.find_by(email: user_email.downcase).present?
-      user_id = User.find_by(email: user_email.downcase).id
-      user = User.find(user_id)
-
-      # すでに招待される側がプランを持っているか確認
-      if user.plan_ids.include?(plan_id.to_i)
-        redirect_to plan_path(plan_id), alert: t('devise.invitations.already_registered_plan', email: user_email)
+    respond_to do |format|
+      # 既存ユーザーの処理
+      if User.find_by(email: user_email.downcase).present?
+        user_id = User.find_by(email: user_email.downcase).id
+        user = User.find(user_id)
+      
+        # すでに招待される側がプランを持っているか確認
+        if user.plan_ids.include?(plan_id.to_i)
+          format.turbo_stream do
+            flash.now[:alert] = t('devise.invitations.already_registered_plan', email: user_email)
+            render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
+          end
+        else
+          user.invite!(current_user)
+          # invited_plan_idに一時的にplan_idを保存
+          user.invited_plan_id = plan_id
+          user.save
+          format.turbo_stream do
+            flash.now[:notice] = t('devise.invitations.send_instructions', email: user_email)
+            render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
+          end
+        end
+      elsif User.invite!(email: user_email, invited_plan_id: plan_id, name: "仮ユーザー名").valid? # 新規ユーザーの処理
+        format.turbo_stream do
+          flash.now[:notice] = t('devise.invitations.send_instructions', email: user_email)
+          render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
+        end
       else
-        user.invite!(current_user)
-        # invited_plan_idに一時的にplan_idを保存
-        user.invited_plan_id = plan_id
-        user.save
-        redirect_to plan_path(plan_id), notice: t('devise.invitations.send_instructions', email: user_email)
+        flash[:alert] = t('devise.invitations.failure')
+        render 'new', locals: { id: plan_id }
       end
-    elsif User.invite!(email: user_email, invited_plan_id: plan_id, name: "仮ユーザー名").valid? # 新規ユーザーの処理
-      redirect_to plan_path(plan_id), notice: t('devise.invitations.send_instructions', email: user_email)
-    else
-      flash[:notice] = t('devise.invitations.failure')
-      render 'new', locals: { id: plan_id }
     end
   end
 

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -32,8 +32,10 @@ class Users::InvitationsController < Devise::InvitationsController
           render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
         end
       else
-        flash[:alert] = t('devise.invitations.failure')
-        render 'new', locals: { id: plan_id }
+        format.turbo_stream do
+          flash.now[:alert] = t('devise.invitations.failure')
+          render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
+        end
       end
     end
   end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import RemovalsController from "./removals_controller"
+application.register("removals", RemovalsController)

--- a/app/javascript/controllers/removals_controller.js
+++ b/app/javascript/controllers/removals_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="removals"
+export default class extends Controller {
+  connect() {
+    this.startRemovalTimer()
+  }
+
+  startRemovalTimer() {
+    setTimeout(() => {
+      this.remove()
+    }, 5000) // 5秒後にメッセージを削除
+  }
+
+  remove() {
+    this.element.remove()
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,9 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <%= render 'shared/flash_message' %>
+    <div id="flash">
+      <%= render 'shared/flash_message' %>
+    </div>
     <div class="pb-36 md:pb-48">
       <%= turbo_frame_tag 'modal' %>
       <%= yield %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= flash_color(message_type) %> px-4 py-2 rounded-xl mb-4">
+  <div class="<%= flash_color(message_type) %> px-4 py-2 rounded-xl mb-4" data-controller="removals">
     <%= message %>
   </div>
 <% end %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,5 +1,6 @@
 <div id="spot-form">
   <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
+    <%= render 'shared/error_messages', object: f.object %>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
       <%= f.text_field :name, class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
       <%= f.submit "登録", class:"text-base-content btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,6 +1,5 @@
 <div id="spot-form">
   <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
-    <%= render 'shared/error_messages', object: f.object %>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
       <%= f.text_field :name, class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
       <%= f.submit "登録", class:"text-base-content btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -4,6 +4,7 @@
     <%= render "spot", spot: @spot, plan: @planned_spot.plan %>
   <% end %>
 <% end %>
+<%= turbo_stream.prepend "flash", partial: "shared/flash_message" %>
 <%= turbo_stream.replace "spot-form" do %>
   <%= render "form", spot: Spot.new, plan: @planned_spot.plan %>
 <% end %>

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -4,7 +4,7 @@ ja:
       invited: 'アカウントを作成するには、保留中の招待を承認してください'
     invitations:
       send_instructions: '招待メールが%{email}に送信されました'
-      failure: '送信ができませんでした'
+      failure: '送信できませんでした メールアドレスを確認してください'
       already_registered_plan: '%{email}はすでにこのプランのメンバーです'
       invitation_token_invalid: '招待コードが不正です'
       updated: 'パスワードが設定されました お使いのアカウントでログインできます'


### PR DESCRIPTION
### 概要
フラッシュメッセージがページをリロードしなくても表示される

### 実装ページ
- 招待機能のページ
![b7dd729650f657876e2d18ab7095c357](https://github.com/maru973/Tripot_Share/assets/148407473/6d7a75fa-2784-4e83-87cc-79d1bfe1fefc)

- スポット登録のページ
![8f48ac0fdb68386e73bdbba066d1dff1](https://github.com/maru973/Tripot_Share/assets/148407473/aa15536e-ab19-47f9-8f3c-58b8dcd5fd87)



### 内容
- [x] turbo_streamを使ってフラッシュメッセージを表示
- [x] フラッシュメッセージが5秒後に消える  
