### PR TITLE
【bug】ページを遷移してもマップが初期化されない現象の解消 close #127

### DIFF
--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,40 +1,33 @@
 <%= turbo_frame_tag 'modal' do %>
-
-    <dialog data-modal-target="dialog" class="p-6 rounded-lg backdrop:bg-black/50 text-base-content">
-      <div class="flex justify-end">
-        <button autofocus data-action="modal#close">
-          <span class="material-symbols-outlined">
-            close
-          </span>
-        </button>
-      </div>
-      <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= t "devise.invitations.new.header" %></h2>
-      <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
-
-        <% resource.class.invite_key_fields.each do |field| -%>
-          <% f.label field, class:"text-md" %>
-          <p class="text-xs md:text-sm text-center">招待メールを送る場合は下記フォームに<br />招待したいメンバーのメールアドレスを<br class="md:hidden" />入力してください</p>
-          <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
-            <%= f.email_field field, class: "input input-sm md:input-md w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder: "example@example.com" %>
-            <!-- plan_idも一緒に設定 -->
-            <%= f.hidden_field :plan_id, value: params[:id] %>
-
-            <div class="actions">
-              <%= f.submit t("devise.invitations.new.submit_button"), class: "text-base-content btn btn-sm md:btn-md btn-secondary rounded-none rounded-r-lg" %>
-            </div>
+  <dialog data-modal-target="dialog" class="p-6 rounded-lg backdrop:bg-black/50 text-base-content">
+    <div class="flex justify-end">
+      <button autofocus data-action="modal#close">
+        <span class="material-symbols-outlined">
+          close
+        </span>
+      </button>
+    </div>
+    <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center"><%= t "devise.invitations.new.header" %></h2>
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <% resource.class.invite_key_fields.each do |field| -%>
+        <% f.label field, class:"text-md" %>
+        <p class="text-xs md:text-sm text-center">招待メールを送る場合は下記フォームに<br />招待したいメンバーのメールアドレスを<br class="md:hidden" />入力してください</p>
+        <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
+          <%= f.email_field field, class: "input input-sm md:input-md w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder: "example@example.com" %>
+          <!-- plan_idも一緒に設定 -->
+          <%= f.hidden_field :plan_id, value: params[:id] %>
+          <div class="actions">
+            <%= f.submit t("devise.invitations.new.submit_button"), class: "text-base-content btn btn-sm md:btn-md btn-secondary rounded-none rounded-r-lg" %>
           </div>
-        <% end -%>
-
-      <% end %>
-      <%= turbo_frame_tag 'invite_link' do %>
-        <%= render 'plans/invitation_url_button' %>
-        <div class="flex justify-center">
-          <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"text-base-content btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
         </div>
-      <% end %>
-    </dialog>
-
- 
-  
+      <% end -%>
+    <% end %>
+    <%= turbo_frame_tag 'invite_link' do %>
+      <%= render 'plans/invitation_url_button' %>
+      <div class="flex justify-center">
+        <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"text-base-content btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
+      </div>
+    <% end %>
+  </dialog>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>App</title>
+    <title>Tripot Share</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/plans/_plan.html.erb
+++ b/app/views/plans/_plan.html.erb
@@ -32,10 +32,10 @@
     </div>
 
     <div class="card-actions justify-end md:hidden">
-      <%= link_to t('defaults.show'), plan_path(plan), class:"link" %>
+      <%= link_to t('defaults.show'), plan_path(plan), class:"link", data: { turbo: false } %>
     </div>
   </div>
   <div class="card-actions justify-end mb-4 mr-7 group-hover:opacity-100 md:opacity-0 transform transition-all delay-200 duration-300">
-    <%= link_to t('defaults.show'), plan_path(plan), class:"link" %>
+    <%= link_to t('defaults.show'), plan_path(plan), class:"link", data: { turbo: false } %>
   </div>
 </div>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -33,7 +33,7 @@
         </div>
 
         <div class="flex justify-center mt-3">
-          <%= f.submit "次へ", class: "text-base-content btn btn-sm md:btn-md btn-accent" %>
+          <%= f.submit "次へ", class: "text-base-content btn btn-sm md:btn-md btn-accent", data: { turbo: false } %>
         </div>
       <% end %>
     </div>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -20,11 +20,6 @@
 
 
 <script>
-  // 他のファイルでも使用できるようにfunctionの外側で定義
-  let map
-
-  let markers = [];
-
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {
@@ -71,5 +66,5 @@
 
 </script>
 <!-- google mapのスクリプト -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly&libraries=marker" defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places,marker&v=weekly" async defer></script>
 

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -12,7 +12,7 @@
 
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">
-    <%= link_to "一時保存", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to "一時保存", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg", data: { turbo: false }  %>
   </div>
   
 </article>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -20,6 +20,8 @@
 
 
 <script>
+  const baseUrl = '<%= request.base_url %>';
+
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {
@@ -30,9 +32,6 @@
       keyboardShortcuts: false,
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
-
-    const baseUrl = '<%= request.base_url %>';
-
 
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -65,6 +65,8 @@
 
   let markers = [];
 
+  const baseUrl = '<%= request.base_url %>';
+
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -76,9 +76,6 @@
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
 
-    const baseUrl = '<%= request.base_url %>';
-
-
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>
       (() => {

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -110,4 +110,4 @@
 
 </script>
 <!-- google mapのスクリプト -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly&libraries=marker" defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places,marker&v=weekly" async defer></script>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -111,6 +111,3 @@
 </script>
 <!-- google mapのスクリプト -->
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places&v=weekly&libraries=marker" defer></script>
-<style>
-
-</style>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -12,7 +12,7 @@
         </div>
         <ul tabindex="0" class="border dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-40 md:w-52">
           <li class="text-xs md:text-lg">
-            <%= link_to new_spots_plan_path(@plan) do %>
+            <%= link_to new_spots_plan_path(@plan), data: { turbo: false } do %>
               <span class= "material-symbols-outlined" style= "font-size: 20px;">
                 add_location_alt
               </span>

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,28 +1,22 @@
 <script>
-    const baseUrl = '<%= request.base_url %>';
-
-      (() => {
-        let glyphImg = document.createElement("img");
-
-        const avatarUrl = '<%= current_user.avatar_url %>'.startsWith('http')
-          ? '<%= current_user.avatar_url %>'
-          : new URL('<%= current_user.avatar_url %>', baseUrl).href;
-
-        glyphImg.src = avatarUrl;
-        glyphImg.className = 'glyph-img';    
-
-        let glyphSvgPinView = new google.maps.marker.PinElement({
-          glyph: glyphImg,
-          
-        });
-
-        let marker = new google.maps.marker.AdvancedMarkerElement({
-          map: map,
-          position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
-          id: <%= @spot.id %>,
-          content: glyphSvgPinView.element,
-        });
-      })();
+  (() => {
+    let glyphImg = document.createElement("img");
+    const avatarUrl = '<%= current_user.avatar_url %>'.startsWith('http')
+      ? '<%= current_user.avatar_url %>'
+      : new URL('<%= current_user.avatar_url %>', baseUrl).href;
+    glyphImg.src = avatarUrl;
+    glyphImg.className = 'glyph-img';    
+    let glyphSvgPinView = new google.maps.marker.PinElement({
+      glyph: glyphImg,
+      
+    });
+    let marker = new google.maps.marker.AdvancedMarkerElement({
+      map: map,
+      position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
+      id: <%= @spot.id %>,
+      content: glyphSvgPinView.element,
+    });
+  })();
 
 
   // マーカーを削除


### PR DESCRIPTION
### 概要
ページを遷移してもマップが初期化されない現象の解消

### 実装ページ
![4186291345e809b32955dcfdee77c8f4](https://github.com/maru973/Tripot_Share/assets/148407473/553e945a-49fe-42b2-85e3-88033de5a916)

![f73c78fc082dd3e9ef9a181113d21f5f](https://github.com/maru973/Tripot_Share/assets/148407473/3b74179b-be85-4389-ba14-8d3edbdd7154)



### 内容
- [x] 地図表示ページに遷移する前のリンクにdata: { turbo: false }を追加
- [x] showページを開いたらそのプランのlocationが表示
- [x] 前回開いた地図が次開いた地図に残らない
- [x] 地図の初期化が正常にされる
- [x] スポットの新規登録をしてもコンソールでエラーが表示されない     


### 補足
地図が初期化されなかったのはturbo driveが前回のJSコードの情報を保持してページを遷移してたため、turbo driveを無効にしたところ正常に初期化がされた。