### PR TITLE
【bug】スポットを削除した時、マーカーがリロードしないと消えない現象の解消 close #125

### DIFF
--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -20,6 +20,8 @@
 
 
 <script>
+  let markers = [];
+  
   const baseUrl = '<%= request.base_url %>';
 
   // マップの初期化設定
@@ -56,11 +58,32 @@
         let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
-          id: <%= spot.id %>,
           content: glyphSvgPinView.element,
         });
+        marker.id = "<%= spot.id %>";
+        markers.push(marker);
+        console.log(markers);
       })();
     <% end %>
+  }
+
+  function del(markerId) {
+  let marker = markers.find(marker => marker.id === parseInt(markerId));
+  if (marker) {
+    marker.setMap(null);
+  }
+}
+
+function removeMarker(markerId) {
+    // マーカー配列の中から指定されたspot.idのマーカーを探して削除する
+    markers = markers.filter(marker => {
+      if (marker.id === markerId) {
+        marker.setMap(null); // マーカーを地図から削除
+        return false; // 配列から削除
+      }
+      return true; // 配列に残す
+    });
+    console.log(markers);
   }
 
 </script>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -60,30 +60,22 @@
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
           content: glyphSvgPinView.element,
         });
-        marker.id = "<%= spot.id %>";
+        marker.id = <%= spot.id %>;
         markers.push(marker);
         console.log(markers);
       })();
     <% end %>
   }
 
-  function del(markerId) {
-  let marker = markers.find(marker => marker.id === parseInt(markerId));
-  if (marker) {
-    marker.setMap(null);
-  }
-}
-
-function removeMarker(markerId) {
+  function removeMarker(markerId) {
     // マーカー配列の中から指定されたspot.idのマーカーを探して削除する
     markers = markers.filter(marker => {
-      if (marker.id === markerId) {
+      if (marker.id == markerId) {
         marker.setMap(null); // マーカーを地図から削除
         return false; // 配列から削除
       }
       return true; // 配列に残す
     });
-    console.log(markers);
   }
 
 </script>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -108,6 +108,17 @@
     <% end %>
   }
 
+  function removeMarker(markerId) {
+    // マーカー配列の中から指定されたspot.idのマーカーを探して削除する
+    markers = markers.filter(marker => {
+      if (marker.id == markerId) {
+        marker.setMap(null); // マーカーを地図から削除
+        return false; // 配列から削除
+      }
+      return true; // 配列に残す
+    });
+  }
+
 </script>
 <!-- google mapのスクリプト -->
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places,marker&v=weekly" async defer></script>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -100,9 +100,10 @@
         let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
-          id: <%= spot.id %>,
           content: glyphSvgPinView.element,
         });
+        marker.id = <%= spot.id %>;
+        markers.push(marker);
       })();
     <% end %>
   }

--- a/app/views/spots/_marker.html.erb
+++ b/app/views/spots/_marker.html.erb
@@ -1,30 +1,26 @@
-<script>
-  (() => {
+<script>  
+  function addMarker() {
     let glyphImg = document.createElement("img");
+
     const avatarUrl = '<%= current_user.avatar_url %>'.startsWith('http')
       ? '<%= current_user.avatar_url %>'
       : new URL('<%= current_user.avatar_url %>', baseUrl).href;
+
     glyphImg.src = avatarUrl;
-    glyphImg.className = 'glyph-img';    
+    glyphImg.className = 'glyph-img';  
+
     let glyphSvgPinView = new google.maps.marker.PinElement({
       glyph: glyphImg,
-      
     });
     let marker = new google.maps.marker.AdvancedMarkerElement({
       map: map,
       position: {lat: <%= @spot.latitude %>, lng: <%= @spot.longitude %>},
-      id: <%= @spot.id %>,
       content: glyphSvgPinView.element,
     });
-  })();
-
-
-  // マーカーを削除
-  function removeMarker(markerId) {
-    const markerIndex = markers.findIndex(marker => marker.id === markerId);
-    if (markerIndex !== -1) {
-      markers[markerIndex].setMap(null); // マーカーをマップから削除
-      markers.splice(markerIndex, 1); // 配列からマーカーを削除
-    }
+    marker.id = <%= @spot.id %>;
+    markers.push(marker);
   }
+
+
+  addMarker();
 </script>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -13,7 +13,7 @@
     <% end %>
   </td>
   <td class="hidden md:block">
-    <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } %>
+    <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
   </td>
   <td class="md:hidden">
     <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } do %>

--- a/app/views/spots/destroy.turbo_stream.erb
+++ b/app/views/spots/destroy.turbo_stream.erb
@@ -1,7 +1,3 @@
-<%= turbo_stream.remove "map-marker-#{@spot.id}" %>
 <%= turbo_stream.remove "spot-#{@spot.id}" do %>
   <%= render "spot", spot: @spot %>
 <% end %>
-<script>
-  removeMarker(<%= @spot.id %>);
-</script>


### PR DESCRIPTION
### 概要
スポットを削除した時、マーカーがリロードしないと消えない現象の解消

### 実装ページ
![ad86bf537aac2107e107b49036c440d8](https://github.com/maru973/Tripot_Share/assets/148407473/90ecb4f0-684d-4a29-b334-a200e2109792)


### 内容
- [x] ページをリロードしなくてもマーカーが削除できる 
- [x] マーカーを追加するときに配列に入れて、その配列から削除する


### 補足
marker.id がstring型でmarkerIdがnumber型でmarker.id === markerIdだとマーカーの削除ができないため、marker.id == markerIdで記述。
