### PR TITLE
【bug】スマホ用の削除ボタンでもリロードしなくてもマーカー削除ができるように設定

### DIFF
--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -62,7 +62,6 @@
         });
         marker.id = <%= spot.id %>;
         markers.push(marker);
-        console.log(markers);
       })();
     <% end %>
   }

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -16,7 +16,7 @@
     <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
   </td>
   <td class="md:hidden">
-    <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') } do %>
+    <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" do %>
       <span class="material-symbols-outlined">
         delete
       </span>


### PR DESCRIPTION
### 概要
スマホ用の削除ボタンでもリロードしなくてもマーカー削除ができるように設定

### 内容
- [x] スマホの削除ボタンからマーカーをページリロードをしなくても削除できる 
