### PR TITLE
【feature】メール送信での招待URLの有効期限を設定 close #172

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,6 +2,8 @@
 
 <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
 
+<p><%= t("devise.mailer.invitation_instructions.expired_url") %></p>
+
 <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
 
 <% if @resource.invitation_due_at %>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -2,6 +2,8 @@
 
 <%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
 
+<%= t("devise.mailer.invitation_instructions.expired_url") %>
+
 <%= accept_invitation_url(@resource, invitation_token: @token) %>
 
 <% if @resource.invitation_due_at %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -138,7 +138,7 @@ Devise.setup do |config|
   # The period the generated invitation token is valid.
   # After this period, the invited resource won't be able to accept the invitation.
   # When invite_for is 0 (the default), the invitation won't expire.
-  # config.invite_for = 2.weeks
+  config.invite_for = 15.minutes
 
   # Number of invitations users can send.
   # - If invitation_limit is nil, there is no limit for invitations, users can

--- a/config/locales/devise_invitable.ja.yml
+++ b/config/locales/devise_invitable.ja.yml
@@ -22,6 +22,7 @@ ja:
         subject: '旅行メンバーに招待されました'
         hello: '%{email}さん'
         someone_invited_you: '%{url}に招待されました。以下のリンクから参加できます。'
+        expired_url: '下記URLの有効期限は15分です。有効期限が切れた場合は、再度招待の依頼をしてください。'
         accept: 'このプランに参加する'
         accept_until: 'この招待は%{due_date}まで有効です。'
         ignore: '身に覚えがない場合は、このメールを無視してください。'


### PR DESCRIPTION
### 概要
メール送信での招待URLの有効期限を設定

### 内容
- [x] メールで送信した招待URLの有効期限を15分に設定 


### 補足
トークンを生成した招待URLの有効期限は後日行う予定。