### PR TITLE
【feature】ボタンを押したら招待URLがコピーできる close #171

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="clipboard"
+export default class extends Controller {
+  static targets = ['link']
+
+  copyToClipboard(event) {
+    event.preventDefault();
+    navigator.clipboard.writeText(this.linkTarget.textContent)
+      .then(() => {
+        alert("招待リンクをコピーしました");
+      })
+      .catch(err => {
+        alert("招待リンクのコピーに失敗しました");
+      });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -24,10 +24,12 @@
       <% end -%>
     <% end %>
     <%= turbo_frame_tag 'invite_link' do %>
-      <%= render 'plans/invitation_url_button' %>
-      <div class="flex justify-center">
-        <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"text-base-content btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
-      </div>
+      <%= render 'plans/invitation_url' %>
+      <% unless @invite_link.present? %>
+        <div class="flex justify-center">
+          <%= link_to "リンクを生成", invitation_plan_path(params[:id]), class:"text-base-content btn btn-accent btn-sm md:btn-md", data: {turbo_method: :post, turbo_frame: "invite_link"} %>
+        </div>
+      <% end %>
     <% end %>
   </dialog>
 <% end %>

--- a/app/views/plans/_invitation_url.html.erb
+++ b/app/views/plans/_invitation_url.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag 'invite_link' do %>
   <% if @invite_link.present? %>
     <div class="flex flex-col" data-controller="clipboard">
-      <div data-clipboard-target='link' class="underline">
+      <div data-clipboard-target='link' class="underline break-words">
         <%= @invite_link %>
       </div>
-      <button data-action="clipboard#copyToClipboard" class="text-base-content btn btn-xs text-xs sm:text-sm">
+      <button data-action="clipboard#copyToClipboard" class="text-base-content btn btn-sm text-sm sm:text-sm mx-auto my-3">
         リンクをコピーする
       </button>
     </div>

--- a/app/views/plans/_invitation_url_button.html.erb
+++ b/app/views/plans/_invitation_url_button.html.erb
@@ -1,7 +1,6 @@
-
 <%= turbo_frame_tag 'invite_link' do %>
   <% if @invite_link.present? %>
-    <div class="flex flex-col ">
+    <div class="flex flex-col" data-controller="clipboard">
       <div data-clipboard-target='link' class="underline">
         <%= @invite_link %>
       </div>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -51,10 +51,6 @@
     <!-- 一覧ページボタン --> 
     <%= link_to t('.back_index'), plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
-
-  
-
-  <%= render 'plans/invitation_url_button' %>
 </article>
 
 


### PR DESCRIPTION
### 概要
ボタンを押したら招待URLがコピーできる

### 実装ページ
![c350bedd197d7c5b1ee943bf57e50797](https://github.com/maru973/Tripot_Share/assets/148407473/1cd0f4f3-5065-49ab-83f9-cf293b406c02)


### 内容
- [x] コピーボタンを押したらURLをコピーできる
- [x] URLが表示されているときは生成ボタンを非表示にする  
