### PR TITLE
【feature】ゲストログイン機能の実装 close #8

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   def check_guest
     email = current_user&.email || resource&.email || params[:user][:email].downcase
     if email === 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません'
+      redirect_to root_path, alert: 'この機能はゲストユーザーでは使えません'
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,11 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:invite) { |u| u.permit(:email, :name, :plan_id) }
     devise_parameter_sanitizer.permit(:accept_invitation) { |u| u.permit(:password, :password_confirmation, :invitation_token, :name, :plan_id, :email) }
   end
+
+  def check_guest
+    email = resource&.email || params[:user][:email].downcase
+    if email === 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません'
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
   def check_guest
     email = current_user&.email || resource&.email || params[:user][:email].downcase
-    if email === 'guest@example.com'
+    if email === ENV['GUEST_USER_EMAIL']
       redirect_to root_path, alert: 'この機能はゲストユーザーでは使えません'
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   end
 
   def check_guest
-    email = resource&.email || params[:user][:email].downcase
+    email = current_user&.email || resource&.email || params[:user][:email].downcase
     if email === 'guest@example.com'
       redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません'
     end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,4 +1,5 @@
 class MypagesController < ApplicationController
+  before_action :check_guest, only: :update
   def show; end
 
   def edit

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,5 +1,5 @@
 class PlansController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[show index]
+  skip_before_action :authenticate_user!, only: %i[show index accept]
 
   def index
     @q = Plan.ransack(params[:q])
@@ -34,7 +34,7 @@ class PlansController < ApplicationController
   def new_spots
     @plan = Plan.find(params[:id])
     @location = Spot.find_by(name: @plan.location)
-    
+
     # memberのみ編集可
     if current_user.member?(@plan.id)
       @spot = Spot.new
@@ -103,10 +103,12 @@ class PlansController < ApplicationController
   def invitation
     @plan = Plan.find(params[:id])
 
-    if @plan.generate_token
-      @invite_link = accept_plan_url(invitation_token: @plan.invitation_token) 
-    else
-      redirect_to plan_path(@plan), alert: "招待リンクが作成できませんでした"
+    unless current_user.email === ENV['GUEST_USER_EMAIL']
+      if @plan.generate_token
+        @invite_link = accept_plan_url(invitation_token: @plan.invitation_token) 
+      else
+        redirect_to plan_path(@plan), alert: "招待リンクが作成できませんでした"
+      end
     end
   end
 

--- a/app/controllers/users/Invitations_controller.rb
+++ b/app/controllers/users/Invitations_controller.rb
@@ -1,4 +1,6 @@
 class Users::InvitationsController < Devise::InvitationsController
+  before_action :check_guest, only: %i[create update]
+
   def create
     self.resource = resource_class.new
     user_email = params[:user][:email]

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,9 @@
+class Users::PasswordsController < Devise::PasswordsController
+  before_action :ensure_normal_user, only: :create
+
+  def ensure_normal_user
+    if params[:user][:email].downcase == 'guest@example.com'
+      redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません。'
+    end
+  end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,9 +1,3 @@
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :ensure_normal_user, only: :create
-
-  def ensure_normal_user
-    if params[:user][:email].downcase == 'guest@example.com'
-      redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません。'
-    end
-  end
+  before_action :check_guest, only: :create
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,10 +1,3 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :check_guest, only: %i[update destroy]
-
-  def check_guest
-    if resource.email === 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません'
-    end
-  end
-
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,10 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :check_guest, only: %i[update destroy]
+
+  def check_guest
+    if resource.email === 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません'
+    end
+  end
+
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,6 @@
 class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
-    user = User.find_or_create_by!(email: 'guest@example.com') do |user|
+    user = User.find_or_create_by!(email: ENV['GUEST_USER_EMAIL']) do |user|
       user.password = SecureRandom.urlsafe_base64
       user.name = 'ゲスト'
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,6 +5,6 @@ class Users::SessionsController < Devise::SessionsController
       user.name = 'ゲスト'
     end
     sign_in user
-    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました'
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,10 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    user = User.find_or_create_by!(email: 'guest@example.com') do |user|
+      user.password = SecureRandom.urlsafe_base64
+      user.name = 'ゲスト'
+    end
+    sign_in user
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -55,6 +55,15 @@
         </div>
       <% end %>
 
+      <div class="border-b text-gray-600 pt-4"></div> 
+        <div class="px-2 text-xs md:text-sm text-gray-500">
+          お試しでアプリを触ってみたい方は下のボタンからゲストとしてログインしてください
+        </div>
+        <div class="flex justify-center pt-2">
+          <%= link_to 'ゲストログイン', users_guest_sign_in_path, class:"text-base-content btn btn-sm", data: {turbo_method: :post} %>
+        </div>
+      </div>
+
       <%= render "devise/shared/links" %>
     </div>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -45,6 +45,15 @@
         </div>
       <% end %>
 
+      <div class="border-b text-gray-600 pt-4"></div> 
+        <div class="px-2 text-xs md:text-sm text-gray-500">
+          お試しでアプリを触ってみたい方は下のボタンからゲストとしてログインしてください
+        </div>
+        <div class="flex justify-center pt-2">
+          <%= link_to 'ゲストログイン', users_guest_sign_in_path, class:"text-base-content btn btn-sm", data: {turbo_method: :post} %>
+        </div>
+      </div>
+
       <%= render "devise/shared/links" %>
     </div>
   </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -19,7 +19,7 @@
       </div>
     </div>
     <div class="flex justify-end pr-5 pb-4">
-      <%= link_to "アカウント削除", user_registration_path, class:"text-base-content btn btn-error btn-sm", data: {turbo_method: :delete, turbo_confirm: "本当にアカウントを削除しますか" } %>
+      <%= link_to "アカウント削除", user_registration_path, class:"text-base-content btn btn-error btn-sm bg-opacity-90", data: {turbo_method: :delete, turbo_confirm: "本当にアカウントを削除しますか" } %>
     </div>
   </div>
 </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -18,5 +18,8 @@
         <%= link_to "編集", edit_mypage_path, class:"text-base-content btn btn-primary", data: { turbo_stream: true } %>
       </div>
     </div>
+    <div class="flex justify-end pr-5 pb-4">
+      <%= link_to "アカウント削除", user_registration_path, class:"text-base-content btn btn-error btn-sm", data: {turbo_method: :delete, turbo_confirm: "本当にアカウントを削除しますか" } %>
+    </div>
   </div>
 </div>

--- a/app/views/plans/invitation.html.erb
+++ b/app/views/plans/invitation.html.erb
@@ -2,7 +2,7 @@
   <div id="invite-link">
     <div class="flex flex-col" data-controller="clipboard">
       <% if current_user.email === ENV['GUEST_USER_EMAIL'] %>
-        <p>ゲストユーザーでは招待リンクを生成できません</p>
+        <p class="text-center">ゲストユーザーでは招待リンクを生成できません</p>
       <% else %>
         <div data-clipboard-target='link' class="underline break-words">
           <%= @invite_link %>

--- a/app/views/plans/invitation.html.erb
+++ b/app/views/plans/invitation.html.erb
@@ -1,12 +1,17 @@
 <%= turbo_frame_tag "invite-link" do %>
   <div id="invite-link">
     <div class="flex flex-col" data-controller="clipboard">
-      <div data-clipboard-target='link' class="underline break-words">
-        <%= @invite_link %>
-      </div>
-      <button data-action="clipboard#copyToClipboard" class="text-base-content btn btn-sm text-sm sm:text-sm mx-auto my-3">
-        リンクをコピーする
-      </button>
+      <% if current_user.email === ENV['GUEST_USER_EMAIL'] %>
+        <p>ゲストユーザーでは招待リンクを生成できません</p>
+      <% else %>
+        <div data-clipboard-target='link' class="underline break-words">
+          <%= @invite_link %>
+        </div>
+    
+        <button data-action="clipboard#copyToClipboard" class="text-base-content btn btn-sm text-sm sm:text-sm mx-auto my-3">
+          リンクをコピーする
+        </button>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -5,6 +5,7 @@
   </div>
   <div>
     <ul class="flex justify-end menu menu-horizontal md:m-2">
+      <li class="hidden md:block link link-hover"><%= link_to "みんなのプランをみる", plans_path %></li>
       <li class="link link-hover" ><%= link_to "アカウント登録", new_user_registration_path %></li>
       <li class="link link-hover"><%= link_to "ログイン", new_user_session_path %></li>
     </ul>

--- a/app/views/spots/_modal.html.erb
+++ b/app/views/spots/_modal.html.erb
@@ -35,10 +35,10 @@
                   info
                 </span>
               </div>
-            <div tabindex="0" class="dropdown-content z-[1] p-2 w-40 shadow bg-accent rounded-lg text-center">
-              <p class="text-sm">今日は<%= l(Date.today, format: :day_name) %>です</p>
+              <div tabindex="0" class="dropdown-content z-[1] p-2 w-40 shadow bg-accent rounded-lg text-center">
+                <p class="text-sm">今日は<%= l(Date.today, format: :day_name) %>です</p>
+              </div>
             </div>
-          </div>
           </div>
           <ul class="pl-5">
             <% spot.opening_hours.split("\n").each do |hour| %>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -1,7 +1,6 @@
 <div class="flex flex-col justify-center items-center m-3">
   <div class="bg-info w-full">
     <div class="pt-4 md:pt-8 text-center">
-      <!--<h1 class="underline m-3">TripotShare</h1>-->
       <h1 class="text-lg md:text-3xl text-base-content text-opacity-80">私たちだけの旅行プラン、</h1>
       <h1 class="text-2xl md:text-4xl font-black">もっと気軽に。もっと楽しく。</h1>
     </div>
@@ -17,6 +16,7 @@
       <%= link_to "プランをつくってみる", new_user_registration_path, class:"text-base-content btn btn-primary btn-sm md:btn-lg" %>
     <% end %>
     <%= link_to "みんなのプランをみる", plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to 'ゲストログイン', users_guest_sign_in_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg", data: {turbo_method: :post} %>
   </div> 
 
   <div class="m-6 pt-4 md:pt-8 w-full md:w-9/12">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     omniauth_callbacks: "omniauth_callbacks",
-    invitations: 'users/invitations'
+    invitations: 'users/invitations',
+    registrations: 'users/registrations',
+    passwords: 'users/passwords'
   }
 
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
     omniauth_callbacks: "omniauth_callbacks",
     invitations: 'users/invitations'
   }
+
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
+  end
   
   get "up" => "rails/health#show", as: :rails_health_check
 


### PR DESCRIPTION
### 概要
ゲストログイン機能の実装

### 実装ページ
 ![2c7a3537a87a91802ff6d894b4f4b59f](https://github.com/maru973/Tripot_Share/assets/148407473/3c0fc8f1-3ffb-4419-b158-9fd8296a5a37) 
![73429033c31233290e9a4fd308db06f9](https://github.com/maru973/Tripot_Share/assets/148407473/b0ee46e0-2f92-46a3-9c7c-7672c9d6eff6)



### 内容
- [x] ゲストログインボタンを押すとゲストとしてログインされる
- [x] アカウント登録ページ、ログインページ、トップページにゲストログインボタン設置
- [x] ゲストユーザーはアカウントの削除、更新は不可
- [x] パスワードの再設定も不可 
- [x] アカウント削除ボタンの設置 


### 補足
ログイン前ヘッダーにみんなのプランをみるボタンを設置。