### PR TITLE
【feature】スポット登録フォームにオートコンプリートを実装 close #27

### DIFF
--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -35,6 +35,13 @@
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
 
+    const input = document.getElementById("pac-input");
+    const options = {
+      fields: ["address_components", "name"],
+    };
+    const autocomplete = new google.maps.places.Autocomplete(input, options);
+    autocomplete.bindTo("bounds", map);
+
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>
       (() => {

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,7 +1,7 @@
 <div id="spot-form">
   <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
-      <%= f.text_field :name, class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
+      <%= f.text_field :name, id:"pac-input", class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
       <%= f.submit "登録", class:"text-base-content btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>
     </div>
   <% end %>


### PR DESCRIPTION
### 概要
スポット登録フォームにオートコンプリートを実装 

### 実装ページ
![06414196b8b90b3d34b3a08ea1cd31bd](https://github.com/maru973/Tripot_Share/assets/148407473/6b777627-1cdf-4228-946a-0e4a68102ffa)
