### PR TITLE
【fix】スポット削除ボタンの表示設定 close #195

### DIFF
--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -30,7 +30,7 @@
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan } %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user_id: user.id} %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -35,12 +35,12 @@
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
 
-    const input = document.getElementById("pac-input");
-    const options = {
-      fields: ["address_components", "name"],
-    };
-    const autocomplete = new google.maps.places.Autocomplete(input, options);
-    autocomplete.bindTo("bounds", map);
+    // const input = document.getElementById("pac-input");
+    // const options = {
+    //   fields: ["address_components", "name"],
+    // };
+    // const autocomplete = new google.maps.places.Autocomplete(input, options);
+    // autocomplete.bindTo("bounds", map);
 
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -46,7 +46,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan  %>
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -46,12 +46,12 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan %>
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan  %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">
     <% if current_user.present? && current_user.id === @plan.owner_id %>
-      <%= link_to t('.destroy'), @plans_path, class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
+      <%= link_to t('.destroy'), plans_path, class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
     <% end %>
 
     <!-- 一覧ページボタン --> 

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,7 +12,7 @@
       </div>
     <% end %>
   </td>
-
+  <% if current_user.present? && current_user.id === user_id %>
     <td class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
     </td>
@@ -23,7 +23,9 @@
         </span>
       <% end %>
     </td>
-
+  <% else %>
+    <td></td>
+  <% end %>
   <th>
     <label>
       <input type="checkbox" class="checkbox" />

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,16 +12,18 @@
       </div>
     <% end %>
   </td>
-  <td class="hidden md:block">
-    <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
-  </td>
-  <td class="md:hidden">
-    <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" do %>
-      <span class="material-symbols-outlined">
-        delete
-      </span>
-    <% end %>
-  </td>
+
+    <td class="hidden md:block">
+      <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
+    </td>
+    <td class="md:hidden">
+      <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" do %>
+        <span class="material-symbols-outlined">
+          delete
+        </span>
+      <% end %>
+    </td>
+
   <th>
     <label>
       <input type="checkbox" class="checkbox" />

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,10 +1,10 @@
 <% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
   <%= turbo_stream.append "spot-table-#{@user.id}" do %>
-    <%= render "spot", spot: @spot, plan: @planned_spot.plan, planned_spot: @planned_spot %>
+    <%= render "spot", spot: @spot, plan: @planned_spot.plan %>
   <% end %>
 <% end %>
 <%= turbo_stream.prepend "flash", partial: "shared/flash_message" %>
 <%= turbo_stream.replace "spot-form" do %>
-  <%= render "form", spot: Spot.new, plan: @planned_spot.plan %>
+  <%= render "form", spot: Spot.new, plan: @planned_spot.plan, user_id: @planned_spot.user_id %>
 <% end %>

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
   <%= turbo_stream.append "spot-table-#{@user.id}" do %>
-    <%= render "spot", spot: @spot, plan: @planned_spot.plan %>
+    <%= render "spot", spot: @spot, plan: @planned_spot.plan, planned_spot: @planned_spot %>
   <% end %>
 <% end %>
 <%= turbo_stream.prepend "flash", partial: "shared/flash_message" %>


### PR DESCRIPTION
### 概要
スポット削除ボタンの表示設定

### 実装ページ
![765e447d7f0cbd48265437b46496ad15](https://github.com/maru973/Tripot_Share/assets/148407473/4f8067c0-d826-4dce-9564-73f2a532aabd)


### 内容
- [x] スポット登録者のみ削除ボタンを表示 


### 補足
オートコンプリートを追加しているとスポット登録する際に、ページをリロードしないといけなくなってしまうみたいなので、一旦コメントアウト。