### PR TITLE
【bug】create turboにローカル変数が設定されてなかったので設定

### DIFF
--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
   <%= turbo_stream.append "spot-table-#{@user.id}" do %>
-    <%= render "spot", spot: @spot, plan: @planned_spot.plan %>
+    <%= render "spot", spot: @spot, plan: @planned_spot.plan, user_id: @planned_spot.user_id %>
   <% end %>
 <% end %>
 <%= turbo_stream.prepend "flash", partial: "shared/flash_message" %>


### PR DESCRIPTION
新規スポット登録をしようとするとエラーが発生。
パーシャルファイルに変数が渡せていなかったので、設定。