### PR TITLE
【fix】new_spotsページの一時保存ボタンを詳細ページへの文言に修正 close #199

### DIFF
--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -12,7 +12,7 @@
 
   <!-- リスト保存ボタン　-->
   <div class="flex justify-center mt-3">
-    <%= link_to "一時保存", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg", data: { turbo: false }  %>
+    <%= link_to "詳細ページへ", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg", data: { turbo: false }  %>
   </div>
   
 </article>


### PR DESCRIPTION
一時保存の文言でボタンを押してないのにページリロードしたら保存されていたというユーザーからの困惑の声があったため、修正。