### PR TITLE
【bug】ポイントがリロードすると他のスポットのポイントになってしまうエラーの解消 close #202

### DIFF
--- a/app/controllers/spot_points_controller.rb
+++ b/app/controllers/spot_points_controller.rb
@@ -9,11 +9,12 @@ class SpotPointsController < ApplicationController
     @spots = @plan.spots
     @user_spots = {}
     @spot_subscribers = {}
+    @spot_points = {}
 
     @spots.each do |spot|
       @spot_subscribers[spot.id] = User.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, spot_id: spot.id })
       @planned_spot = PlannedSpot.find_by(plan_id: @plan.id, spot_id: spot.id)
-      @spot_point = SpotPoint.find_or_create_by(user_id: current_user.id, planned_spot_id: @planned_spot.id)
+      @spot_points[spot.id] = SpotPoint.find_or_create_by(user_id: current_user.id, planned_spot_id: @planned_spot.id)
     end
     
     @users.each do |user|

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -27,12 +27,14 @@
           </li>
 
           <li class="text-xs md:text-lg">
-            <%= link_to plan_spot_points_path(@plan), data: { turbo: false } do %>
-              <span class= "material-symbols-outlined" style= "font-size: 20px;">
-                how_to_vote
-              </span>
-              ランキング投票
-            <% end %>
+            <div class="md:tooltip md:tooltip-left md:tooltip-accent" data-tip="登録したスポットの行きたい度合いを選択してランキングをつろう！">
+              <%= link_to plan_spot_points_path(@plan), data: { turbo: false } do %>
+                <span class= "material-symbols-outlined" style= "font-size: 20px;">
+                  how_to_vote
+                </span>
+                ランキング投票
+              <% end %>
+            </div>
           </li>
 
           <li class="text-xs md:text-lg">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -26,7 +26,7 @@
             <% end %>
           </li>
 
-          <li class="text-xs md:text-lg">
+          <!--<li class="text-xs md:text-lg">
             <div class="md:tooltip md:tooltip-left md:tooltip-accent" data-tip="登録したスポットの行きたい度合いを選択して投票しよう！メンバーが投票した結果を集計してランキングをつくるよ！">
               <%= link_to plan_spot_points_path(@plan), data: { turbo: false } do %>
                 <span class= "material-symbols-outlined" style= "font-size: 20px;">
@@ -35,7 +35,7 @@
                 ランキング投票
               <% end %>
             </div>
-          </li>
+          </li>-->
 
           <li class="text-xs md:text-lg">
             <div data-controller="modal">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -27,6 +27,15 @@
           </li>
 
           <li class="text-xs md:text-lg">
+            <%= link_to plan_spot_points_path(@plan), data: { turbo: false } do %>
+              <span class= "material-symbols-outlined" style= "font-size: 20px;">
+                how_to_vote
+              </span>
+              ランキング投票
+            <% end %>
+          </li>
+
+          <li class="text-xs md:text-lg">
             <div data-controller="modal">
               <%= render template: 'devise/invitations/new', locals: { resource: @user, resource_name: @resource_name } %>
               <%= link_to new_user_invitation_path(id: @plan.id), data: { action: "click->modal#open", turbo_frame: "modal" } do %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -27,7 +27,7 @@
           </li>
 
           <li class="text-xs md:text-lg">
-            <div class="md:tooltip md:tooltip-left md:tooltip-accent" data-tip="登録したスポットの行きたい度合いを選択してランキングをつろう！">
+            <div class="md:tooltip md:tooltip-left md:tooltip-accent" data-tip="登録したスポットの行きたい度合いを選択して投票しよう！メンバーが投票した結果を集計してランキングをつくるよ！">
               <%= link_to plan_spot_points_path(@plan), data: { turbo: false } do %>
                 <span class= "material-symbols-outlined" style= "font-size: 20px;">
                   how_to_vote

--- a/app/views/spot_points/_form.html.erb
+++ b/app/views/spot_points/_form.html.erb
@@ -16,7 +16,7 @@
     <%= form_with model: spot_point do |f|%>
       <div class="flex mx-auto gap-2">
         <% f.label :point %>
-        <%= f.select :point, options_for_select({ "4. 絶対行きたい" => 4, "3. 時間があったら行きたい" => 3, "2. どっちでもいい" => 2, "1. あまり行きたくない" => 1, "0. 今回はパス" => 0 }), {include_blank: ""}, {class: "select select-sm md:select-md select-bordered"} %>
+        <%= f.select :point, options_for_select({ "4. 絶対行きたい" => 4, "3. 時間があったら行きたい" => 3, "2. どっちでもいい" => 2, "1. あまり行きたくない" => 1, "0. 今回はパス" => 0 }, spot_point.point), {}, {class: "select select-sm md:select-md select-bordered"} %>
         <%= f.submit "更新", class:"text-base-content btn btn-sm md:btn-md btn-info" %>
       </div>
     <% end %>

--- a/app/views/spot_points/_list.html.erb
+++ b/app/views/spot_points/_list.html.erb
@@ -26,6 +26,7 @@
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each do |spot| %>
+                  <!-- spot_pointsからspot.idと同じ値のデータを持ってくる。lastだとspot_pointを取り出す。--> 
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
                     <%= render partial: 'spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>

--- a/app/views/spot_points/_list.html.erb
+++ b/app/views/spot_points/_list.html.erb
@@ -26,7 +26,7 @@
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_points: spot_points} %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/spot_points/_list.html.erb
+++ b/app/views/spot_points/_list.html.erb
@@ -26,7 +26,10 @@
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_points: spot_points} %>
+                  <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
+                  <% if spot_point %>
+                    <%= render partial: 'spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                  <% end %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -12,11 +12,7 @@
       </div>
     <% end %>
   </td>
-
-  <!-- spot_pointsからspot.idと同じ値のデータを持ってくる。lastだとspot_pointを取り出す。-->
-  
-    <td class="whitespace-nowrap"><%=  spot_point.point %>ポイント</td>
-
+  <td class="whitespace-nowrap"><%=  spot_point.point %>ポイント</td>
   <td>
     <%= link_to '編集', edit_spot_point_path(spot, plan_id: plan.id), data: { turbo_stream: true }, class:"text-base-content btn btn-sm md:btn-md btn-info" %>
   </td>

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -14,7 +14,7 @@
   </td>
   <td class="whitespace-nowrap"><%=  spot_point.point %>ポイント</td>
   <td>
-    <%= link_to '編集', edit_spot_point_path(spot, plan_id: plan.id), data: { turbo_stream: true } %>
+    <%= link_to '編集', edit_spot_point_path(spot, plan_id: plan.id), data: { turbo_stream: true }, class:"text-base-content btn btn-sm md:btn-md btn-info" %>
   </td>
 </tr>
 

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -12,7 +12,13 @@
       </div>
     <% end %>
   </td>
-  <td class="whitespace-nowrap"><%=  spot_point.point %>ポイント</td>
+
+  <!-- spot_pointsからspot.idと同じ値のデータを持ってくる。lastだとspot_pointを取り出す。-->
+  <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
+  <% if spot_point %>
+    <td class="whitespace-nowrap"><%=  spot_point.point %>ポイント</td>
+  <% end %>
+
   <td>
     <%= link_to '編集', edit_spot_point_path(spot, plan_id: plan.id), data: { turbo_stream: true }, class:"text-base-content btn btn-sm md:btn-md btn-info" %>
   </td>

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -14,10 +14,8 @@
   </td>
 
   <!-- spot_pointsからspot.idと同じ値のデータを持ってくる。lastだとspot_pointを取り出す。-->
-  <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
-  <% if spot_point %>
+  
     <td class="whitespace-nowrap"><%=  spot_point.point %>ポイント</td>
-  <% end %>
 
   <td>
     <%= link_to '編集', edit_spot_point_path(spot, plan_id: plan.id), data: { turbo_stream: true }, class:"text-base-content btn btn-sm md:btn-md btn-info" %>

--- a/app/views/spot_points/index.html.erb
+++ b/app/views/spot_points/index.html.erb
@@ -7,7 +7,8 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_point: @spot_point %>
+
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points %>
 
   <!-- 一覧ページボタン --> 
   <div class="flex justify-around mt-3">

--- a/app/views/spot_points/index.html.erb
+++ b/app/views/spot_points/index.html.erb
@@ -9,9 +9,9 @@
   <!-- 登録済みリスト -->
   <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_point: @spot_point %>
 
+  <!-- 一覧ページボタン --> 
   <div class="flex justify-around mt-3">
-    <!-- 一覧ページボタン --> 
-    <%= link_to t('.back_index'), plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to t('.back_index'), plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 </article>
 


### PR DESCRIPTION
### 概要
ポイントがリロードすると他のスポットのポイントになってしまうエラーの解消

### 実装ページ
![ba70fb11c11417f0f89ee3d5bd4803f0](https://github.com/maru973/Tripot_Share/assets/148407473/b3f55afd-e7ad-4e81-aede-f7c4159e38ad)



### 内容
- [x] それぞれのスポットにユーザーが保存したポイントが表示される
- [x] ページをリロードしても保存されたポイントを表示 
- [x] ランキング投票のリンクからポイント選択に遷移
- [x] 選択肢のブランクを削除して現在保存してる選択肢を入れる   


### 補足
ランキング機能を実装していないため、投票するためのパスに遷移するリンクはコメントアウト。
選択肢にブランクがあると選択できてしまったため、削除して現在選択してるものを初期値として設定。