### PR TITLE
【feature】ランキング機能の実装 close #201

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,5 +1,6 @@
 class PlansController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show index]
+  before_action :point_calculate, only: [:show]
 
   def index
     @q = Plan.ransack(params[:q])
@@ -141,5 +142,13 @@ class PlansController < ApplicationController
 
   def plan_params
     params.require(:plan).permit(:name, :start_date, :end_date, :invitation_token, :location)
+  end
+
+  def point_calculate
+    @plan = Plan.find(params[:id])
+    @spot_points = SpotPoint.joins(:planned_spot)
+      .where(planned_spots: { plan_id: @plan.id })
+      .group('planned_spots.spot_id')
+      .sum(:point)
   end
 end

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -25,8 +25,8 @@
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
-                <% user_spots[user.id].each_with_index do |spot, index| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user: user, index: index } %>
+                <% user_spots[user.id].each do |spot| %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user: user } %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -25,8 +25,8 @@
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
-                <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user_id: user.id } %>
+                <% user_spots[user.id].each_with_index do |spot, index| %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user: user, index: index } %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -41,13 +41,16 @@
                 <th class="md:w-[100px]"></th>
                 <th>スポット名</th>
                 <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]">合計行きたい度</th>
+                <th class="md:w-[100px] md:text-center">みんなの行きたい度</th>
                 <th class="md:w-[100px]"></th>
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user_id: user.id} %>
+                  <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
+                  <% if spot_point %>
+                    <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                  <% end %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/plans/_list.html.erb
+++ b/app/views/plans/_list.html.erb
@@ -41,8 +41,8 @@
                 <th class="md:w-[100px]"></th>
                 <th>スポット名</th>
                 <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
                 <th class="md:w-[100px]">合計行きたい度</th>
+                <th class="md:w-[100px]"></th>
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -17,7 +17,6 @@
         </ul>
       </div>
     </div>
-    <% users.each do |user| %>
     <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
       <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
         <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
@@ -33,14 +32,17 @@
             <tbody id="ranking-table-#">
               <% spots.each do |spot| %>
                 <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
-                <% if spot_point %>
-                  <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                  <% @spot_subscribers[spot.id].each do |user| %>
+                  <% if spot_point %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point} %>
+                  <% end %>
                 <% end %>
               <% end %>
             </tbody>
         </table>
       </div>
     </div>
+    <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
         <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
           <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
@@ -57,7 +59,7 @@
                 <% user_spots[user.id].each do |spot| %>
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point} %>
                   <% end %>
                 <% end %>
               </tbody>

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -3,12 +3,32 @@
     <div class="flex overflow-x-auto">
       <div class="flex-none">
         <ul class="list-reset flex">
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">ランキング</a>
+          </li>
           <% users.each do |user| %>
             <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
               <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
             </li>
           <% end %>
         </ul>
+      </div>
+    </div>
+    <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+      <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+        <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+          <thead>
+            <tr>
+              <th class="md:w-[100px]"></th>
+              <th>スポット名</th>
+              <th class="md:w-[100px]">登録者</th>
+              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]"></th>
+            </tr>
+          </thead>
+            <tbody id="spot-table-#">
+            </tbody>
+        </table>
       </div>
     </div>
     <% users.each do |user| %>
@@ -20,13 +40,16 @@
                 <th class="md:w-[100px]"></th>
                 <th>スポット名</th>
                 <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px] md:text-center">みんなの行きたい度</th>
                 <th class="md:w-[100px]"></th>
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user_id: user.id } %>
+                  <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
+                  <% if spot_point %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                  <% end %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -57,11 +57,9 @@
             </thead>
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each_with_index do |spot, index| %>
-                  <% spot_counter = 1 %>
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
                     <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'user' } %>
-                    <% spot_counter += 1 %>
                   <% end %>
                 <% end %>
               </tbody>

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -3,9 +3,12 @@
     <div class="flex overflow-x-auto">
       <div class="flex-none">
         <ul class="list-reset flex">
+          <!-- ランキングタブ -->
           <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
             <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">ランキング</a>
           </li>
+
+          <!-- ユーザータブ -->
           <% users.each do |user| %>
             <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
               <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
@@ -14,6 +17,7 @@
         </ul>
       </div>
     </div>
+    <% users.each do |user| %>
     <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
       <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
         <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
@@ -22,16 +26,21 @@
               <th class="md:w-[100px]"></th>
               <th>スポット名</th>
               <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]"></th>
+              <th class="md:w-[100px]">みんなの行きたい度</th>
               <th class="md:w-[100px]"></th>
             </tr>
           </thead>
-            <tbody id="spot-table-#">
+            <tbody id="ranking-table-#">
+              <% spots.each do |spot| %>
+                <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
+                <% if spot_point %>
+                  <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                <% end %>
+              <% end %>
             </tbody>
         </table>
       </div>
     </div>
-    <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
         <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
           <table class="table table-sm md:table-md table-pin-rows table-pin-cols">

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -33,9 +33,7 @@
               <% spots.each_with_index do |spot, index| %>
                 <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                 <% spot_subscribers[spot.id].each do |user| %>
-                  <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'ranking' } %>
-                  <% end %>
+                  <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'ranking' } %>
                 <% end %>
               <% end %>
             </tbody>
@@ -58,9 +56,7 @@
               <tbody id="spot-table-<%= user.id %>">
                 <% user_spots[user.id].each_with_index do |spot, index| %>
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
-                  <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'user' } %>
-                  <% end %>
+                  <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'user' } %>
                 <% end %>
               </tbody>
           </table>

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -34,7 +34,7 @@
                 <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                 <% spot_subscribers[spot.id].each do |user| %>
                   <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point} %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, tab_type: 'ranking' } %>
                   <% end %>
                 <% end %>
               <% end %>
@@ -59,7 +59,7 @@
                 <% user_spots[user.id].each do |spot| %>
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point} %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, tab_type: 'user' } %>
                   <% end %>
                 <% end %>
               </tbody>

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -29,12 +29,12 @@
               <th class="md:w-[100px]"></th>
             </tr>
           </thead>
-            <tbody id="ranking-table-#">
-              <% spots.each do |spot| %>
+            <tbody id="ranking-table">
+              <% spots.each_with_index do |spot, index| %>
                 <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                 <% spot_subscribers[spot.id].each do |user| %>
                   <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, tab_type: 'ranking' } %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'ranking' } %>
                   <% end %>
                 <% end %>
               <% end %>
@@ -56,10 +56,12 @@
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
-                <% user_spots[user.id].each do |spot| %>
+                <% user_spots[user.id].each_with_index do |spot, index| %>
+                  <% spot_counter = 1 %>
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
-                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, tab_type: 'user' } %>
+                    <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'user' } %>
+                    <% spot_counter += 1 %>
                   <% end %>
                 <% end %>
               </tbody>

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -32,7 +32,7 @@
             <tbody id="ranking-table-#">
               <% spots.each do |spot| %>
                 <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
-                  <% @spot_subscribers[spot.id].each do |user| %>
+                <% spot_subscribers[spot.id].each do |user| %>
                   <% if spot_point %>
                     <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point} %>
                   <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -57,7 +57,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan %>
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -57,7 +57,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points %>
+  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, spots: @spots %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -57,7 +57,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points %>
+  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -57,7 +57,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, spots: @spots %>
+  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, spots: @spots, spot_subscribers: @spot_subscribers %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -57,7 +57,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, spots: @spots, spot_subscribers: @spot_subscribers %>
+  <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, spots: @spots, spot_subscribers: @spot_subscribers, spot_counter: @spot_counter %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/spot_points/_list.html.erb
+++ b/app/views/spot_points/_list.html.erb
@@ -25,11 +25,11 @@
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
-                <% user_spots[user.id].each_with_index do |spot, index| %>
+                <% user_spots[user.id].each do |spot| %>
                   <!-- spot_pointsからspot.idと同じ値のデータを持ってくる。lastだとspot_pointを取り出す。--> 
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
-                    <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, index: index} %>
+                    <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point } %>
                   <% end %>
                 <% end %>
               </tbody>

--- a/app/views/spot_points/_list.html.erb
+++ b/app/views/spot_points/_list.html.erb
@@ -25,11 +25,11 @@
               </tr>
             </thead>
               <tbody id="spot-table-<%= user.id %>">
-                <% user_spots[user.id].each do |spot| %>
+                <% user_spots[user.id].each_with_index do |spot, index| %>
                   <!-- spot_pointsからspot.idと同じ値のデータを持ってくる。lastだとspot_pointを取り出す。--> 
                   <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
                   <% if spot_point %>
-                    <%= render partial: 'spot', locals: { spot: spot, plan: plan, user_id: user.id, spot_point: spot_point} %>
+                    <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, index: index} %>
                   <% end %>
                 <% end %>
               </tbody>

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -1,5 +1,5 @@
 <tr id="spot-<%= spot.id %>">
-  <td><%= index + 1 %></td>
+  <td></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -1,5 +1,5 @@
 <tr id="spot-<%= spot.id %>">
-  <td>1</td>
+  <td><%= index + 1 %></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>
@@ -7,7 +7,7 @@
     <%= link_to "#", class:"hover:brightness-75" do %>
       <div class="avatar">
           <div class="rounded-full mx-2 md:mx-auto w-7 h-7 md:w-12 md:h-12">
-            <%= image_tag "sample.jpg", alt:"Avatar" %>
+            <%= image_tag user.avatar_url, alt:"Avatar" %>
           </div>
       </div>
     <% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,5 +1,5 @@
 <tr id="spot-<%= spot.id %>">
-  <td><%= index + 1 %></td>
+  <td></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,5 +1,5 @@
 <tr id="spot-<%= spot.id %>">
-  <td>1</td>
+  <td><%= index + 1 %></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>
@@ -7,12 +7,12 @@
     <%= link_to "#", class:"hover:brightness-75" do %>
       <div class="avatar">
           <div class="rounded-full mx-2 md:mx-auto w-7 h-7 md:w-12 md:h-12">
-            <%= image_tag "sample.jpg", alt:"Avatar" %>
+            <%= image_tag user.avatar_url, alt:"Avatar" %>
           </div>
       </div>
     <% end %>
   </td>
-  <% if current_user.present? && current_user.id === user_id %>
+  <% if current_user.present? && current_user.id === user.id %>
     <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
     </th>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,19 +12,19 @@
       </div>
     <% end %>
   </td>
+  <td></td>
   <% if current_user.present? && current_user.id === user_id %>
-    <td class="hidden md:block">
+    <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
-    </td>
-    <td class="md:hidden">
+    </th>
+    <th class="md:hidden">
       <%= link_to spot_path(spot, plan_id:plan.id), data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" do %>
         <span class="material-symbols-outlined">
           delete
         </span>
       <% end %>
-    </td>
+    </th>
   <% else %>
     <td></td>
   <% end %>
-  <th></th>
 </tr>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,7 +12,7 @@
       </div>
     <% end %>
   </td>
-  <td></td>
+  <td class="whitespace-nowrap text-center"><%=  spot_point %>ポイント</td>
   <% if current_user.present? && current_user.id === user_id %>
     <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>

--- a/app/views/spots/_spot_rankig.html.erb
+++ b/app/views/spots/_spot_rankig.html.erb
@@ -11,7 +11,7 @@
       </div>
   </td>
   <td class="whitespace-nowrap text-center"><%=  spot_point %>ポイント</td>
-  <% if current_user.present? && current_user.id === user.id %>
+  <% if tab_type === 'user' && current_user.present? && current_user.id === user.id %>
     <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
     </th>

--- a/app/views/spots/_spot_rankig.html.erb
+++ b/app/views/spots/_spot_rankig.html.erb
@@ -12,6 +12,7 @@
       </div>
     <% end %>
   </td>
+  <td class="whitespace-nowrap text-center"><%=  spot_point %>ポイント</td>
   <% if current_user.present? && current_user.id === user_id %>
     <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>

--- a/app/views/spots/_spot_rankig.html.erb
+++ b/app/views/spots/_spot_rankig.html.erb
@@ -10,7 +10,11 @@
         </div>
       </div>
   </td>
-  <td class="whitespace-nowrap text-center"><%=  spot_point %>ポイント</td>
+  <% if spot_point %>
+    <td class="whitespace-nowrap text-center"><%=  spot_point %>ポイント</td>
+  <% else %>
+    <td class="whitespace-nowrap text-center">0ポイント</td>
+  <% end %>
   <% if tab_type === 'user' && current_user.present? && current_user.id === user.id %>
     <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>

--- a/app/views/spots/_spot_rankig.html.erb
+++ b/app/views/spots/_spot_rankig.html.erb
@@ -1,5 +1,5 @@
 <tr id="spot-<%= spot.id %>">
-  <td>1</td>
+  <td><%= index + 1 %></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>

--- a/app/views/spots/_spot_rankig.html.erb
+++ b/app/views/spots/_spot_rankig.html.erb
@@ -4,16 +4,14 @@
     <%= render 'spots/modal', spot: spot %>
   </td>
   <td>
-    <%= link_to "#", class:"hover:brightness-75" do %>
-      <div class="avatar">
-          <div class="rounded-full mx-2 md:mx-auto w-7 h-7 md:w-12 md:h-12">
-            <%= image_tag "sample.jpg", alt:"Avatar" %>
-          </div>
+      <div class="avatar hover:brightness-75">
+        <div class="rounded-full mx-2 md:mx-auto w-7 h-7 md:w-12 md:h-12">
+          <%= image_tag user.avatar_url, alt:"Avatar" %>
+        </div>
       </div>
-    <% end %>
   </td>
   <td class="whitespace-nowrap text-center"><%=  spot_point %>ポイント</td>
-  <% if current_user.present? && current_user.id === user_id %>
+  <% if current_user.present? && current_user.id === user.id %>
     <th class="hidden md:block">
       <%= link_to "削除", spot_path(spot, plan_id:plan.id), class:"text-base-content btn btn-error", data: {turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete_confirm') }, onclick: "removeMarker(#{spot.id});" %>
     </th>

--- a/app/views/spots/create.turbo_stream.erb
+++ b/app/views/spots/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <% if @planned_spot.save %>
   <%= turbo_stream.append "map", partial: "marker" %>
   <%= turbo_stream.append "spot-table-#{@user.id}" do %>
-    <%= render "spot", spot: @spot, plan: @planned_spot.plan, user_id: @planned_spot.user_id %>
+    <%= render "spot", spot: @spot, plan: @planned_spot.plan, user: current_user %>
   <% end %>
 <% end %>
 <%= turbo_stream.prepend "flash", partial: "shared/flash_message" %>

--- a/app/views/spots/destroy.turbo_stream.erb
+++ b/app/views/spots/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.remove "spot-#{@spot.id}" do %>
-  <%= render "spot", spot: @spot %>
+  <%= render "spot", spot: @spot, user: current_user %>
 <% end %>


### PR DESCRIPTION
### 概要
ランキング機能の実装

### 実装ページ
![b633cf0f2e76d2eabfebb8e61e57a4ec](https://github.com/maru973/Tripot_Share/assets/148407473/c467789c-094c-4b3f-89cb-4ac7ac1206f2)


### 内容
- [x]  各ユーザーが設定したポイントの合計を取得する
- [x] ポイントが高いスポット順に並び替え、上位10個を表示
- [x] ランキングタブはshowページにのみ表示
- [x] アバターをスポット登録者の画像に設定 
- [x] ポイントのデータがない場合は「0ポイント」と表示 
- [x] showページのみタブごとにスポットの連番を表示   


### 補足
暫定的にランキングは上位10個としている。今後ルート作成の制限によっては減少する可能性あり。