### PR TITLE
【bug】ポイントの編集がエラーなくできるようにする close #211

### DIFF
--- a/app/controllers/spot_points_controller.rb
+++ b/app/controllers/spot_points_controller.rb
@@ -33,6 +33,7 @@ class SpotPointsController < ApplicationController
     @spot_point = current_user.spot_points.find(params[:id])
     @spot = @spot_point.planned_spot.spot
     @plan = @spot_point.planned_spot.plan
+    @user = @spot_point.planned_spot.user
     @spot_point.update(spot_point_params)
   end
 

--- a/app/controllers/spot_points_controller.rb
+++ b/app/controllers/spot_points_controller.rb
@@ -27,6 +27,7 @@ class SpotPointsController < ApplicationController
 
   def edit
     @spot_point = current_user.spot_points.find_by(planned_spot_id: @planned_spot.id)
+    @user = @spot_point.planned_spot.user
   end
 
   def update

--- a/app/views/spot_points/_form.html.erb
+++ b/app/views/spot_points/_form.html.erb
@@ -1,5 +1,5 @@
 <tr id="spot-<%= spot.id %>">
-  <td>1</td>
+  <td></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>
@@ -7,7 +7,7 @@
     <%= link_to "#", class:"hover:brightness-75" do %>
       <div class="avatar">
           <div class="rounded-full mx-2 md:mx-auto w-7 h-7 md:w-12 md:h-12">
-            <%= image_tag "sample.jpg", alt:"Avatar" %>
+            <%= image_tag user.avatar_url, alt:"Avatar" %>
           </div>
       </div>
     <% end %>

--- a/app/views/spot_points/edit.turbo_stream.erb
+++ b/app/views/spot_points/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace "spot-#{@spot.id}" do %>
-  <%= render 'form', spot_point: @spot_point, spot: @spot, plan_id: @plan.id %>
+  <%= render 'form', spot_point: @spot_point, spot: @spot, plan_id: @plan.id, user: @user %>
 <% end %>

--- a/app/views/spot_points/index.html.erb
+++ b/app/views/spot_points/index.html.erb
@@ -1,6 +1,6 @@
 <article class="pb-4 flex flex-col justify-center">
   <div class="flex items-center">
-    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7">登録したスポットの行きたい度合いを選択しよう</h2>
+    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center px-7">登録したスポットの行きたい度合いを選択しよう</h2>
   </div>
 
   <!-- 地図の表示 -->

--- a/app/views/spot_points/update.turbo_stream.erb
+++ b/app/views/spot_points/update.turbo_stream.erb
@@ -2,5 +2,5 @@
   <%= render 'form', spot_point: @spot_point, spot: @spot, plan_id: @plan.id %>
 <% end %>
 <%= turbo_stream.replace "spot-#{@spot.id}" do %>
-  <%= render 'spot', spot_point: @spot_point, spot: @spot, plan: @plan %>
+  <%= render 'spot', spot_point: @spot_point, spot: @spot, plan: @plan, user: @user %>
 <% end %>

--- a/app/views/spot_points/update.turbo_stream.erb
+++ b/app/views/spot_points/update.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "spot-#{@spot.id}" do %>
-  <%= render 'form', spot_point: @spot_point, spot: @spot, plan_id: @plan.id %>
+  <%= render 'form', spot_point: @spot_point, spot: @spot, plan_id: @plan.id, user: @user %>
 <% end %>
 <%= turbo_stream.replace "spot-#{@spot.id}" do %>
   <%= render 'spot', spot_point: @spot_point, spot: @spot, plan: @plan, user: @user %>


### PR DESCRIPTION
### 概要
ポイントの編集がエラーなくできるようにする

### 実装ページ
![3741d21367411adf2d9fa183e3ac2b73](https://github.com/maru973/Tripot_Share/assets/148407473/12e214aa-bcd9-4345-92b1-c1a3ad19a3dc)


### 内容
- [x] userの変数をturboファイルに渡す
- [x] formのアバターをスポット登録者の画像に変更  
