### PR TITLE
【bug】招待リンクからユーザーが飛んだ時ログイン後にプランが保存されないエラーの解消 close #214

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,12 @@ class ApplicationController < ActionController::Base
   end
   
   def after_sign_in_path_for(resource_or_scope)
-    plans_path
+    if session[:after_sign_in_path]
+      after_sign_in_path = session[:after_sign_in_path]
+      after_sign_in_path = session.delete(:after_sign_in_path)
+    else
+      plans_path
+    end
   end
   
   def check_guest

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,5 +1,5 @@
 class PlansController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[show index]
+  skip_before_action :authenticate_user!, only: %i[show index accept]
   before_action :point_calculate, only: [:show]
 
   def index
@@ -136,6 +136,10 @@ class PlansController < ApplicationController
         @plan.update(invitation_token: nil)
 
         redirect_to plan_path(@plan), notice:t('defaults.flash_message.already_registered_plan', item: @plan.name)
+      else
+        # ログインしてない場合は招待リンクをセッションとして持たせて、ログインパスに遷移する
+        session[:after_sign_in_path] = accept_plan_url(invitation_token: params[:invitation_token])
+        redirect_to new_user_session_path, alert: t('defaults.flash_message.please_sign_in')
       end
 
     else

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,6 +23,7 @@ ja:
       already_registered_plan: "すでに%{item}のメンバーです"
       invitation_token_invalid: "この招待コードは不正です メンバーにURLの再発行を依頼してください"
       delete_confirm: 削除しますか？
+      please_sign_in: ログインもしくはアカウント登録後にプランに参加できます
   plans:
     index:
       title: みんなのプラン


### PR DESCRIPTION
招待リンク実装後に追加したafter_sign_in_path_forが影響していた模様。
authenticate_user!をスキップ。
招待リンクからログイン画面に飛ぶ場合は招待リンクをセッションとして、保持するように設定。