### PR TITLE
【feature】コースの詳細ページ作成 close #223

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -32,6 +32,10 @@ class CoursesController < ApplicationController
   end
 
   def show
+    @course = Course.find(params[:id])
+    @start_location = Spot.find_by(name: @course.start_location)
+    @end_location = Spot.find_by(name: @course.end_location)
+
     @spot_subscribers = {}
 
     spot_ids = @spot_points.keys

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -7,15 +7,26 @@ class CoursesController < ApplicationController
   def create
     @plan = Plan.find(params[:plan_id])
     @course = @plan.courses.build(course_params)
-    @location = Spot.find_or_initialize_by(name: @plan.location)
-      if @location.new_record?
-        results = Geocoder.search(@plan.location)
-        @latlng = results.first.coordinates
-        @location.latitude = @latlng[0]
-        @location.longitude = @latlng[1]
-        @location.address = results.first.address
-        @location.save
-      end
+    @start_location = Spot.find_or_initialize_by(name: @course.start_location)
+    @end_location = Spot.find_or_initialize_by(name: @course.end_location)
+    if @start_location.new_record?
+      results = Geocoder.search(@course.start_location)
+      @latlng = results.first.coordinates
+      @start_location.latitude = @latlng[0]
+      @start_location.longitude = @latlng[1]
+      @start_location.address = results.first.address
+      @start_location.save
+    end
+    if @end_location.new_record?
+      results = Geocoder.search(@course.end_location)
+      @latlng = results.first.coordinates
+      @end_location.latitude = @latlng[0]
+      @end_location.longitude = @latlng[1]
+      @end_location.address = results.first.address
+      @end_location.save
+    end
+    @course.save
+    redirect_to course_path(@course), notice: 'コースを作成しました'
   end
 
   private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -6,5 +6,21 @@ class CoursesController < ApplicationController
 
   def create
     @plan = Plan.find(params[:plan_id])
+    @course = @plan.courses.build(course_params)
+    @location = Spot.find_or_initialize_by(name: @plan.location)
+      if @location.new_record?
+        results = Geocoder.search(@plan.location)
+        @latlng = results.first.coordinates
+        @location.latitude = @latlng[0]
+        @location.longitude = @latlng[1]
+        @location.address = results.first.address
+        @location.save
+      end
+  end
+
+  private
+
+  def course_params
+    params.require(:course).permit(:start_location, :end_location)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,5 @@
 class Course < ApplicationRecord
   belongs_to :plan
-  belongs_to :planned_spots
 
   validates :start_location, presence: true
   validates :end_location, presence: true

--- a/app/models/planned_spot.rb
+++ b/app/models/planned_spot.rb
@@ -3,5 +3,4 @@ class PlannedSpot < ApplicationRecord
   belongs_to :spot
   belongs_to :user
   has_many :spot_points, dependent: :destroy
-  has_many :courses, dependent: :destroy
 end

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -3,15 +3,13 @@
     <div class="flex overflow-x-auto">
       <div class="flex-none">
         <ul class="list-reset flex">
-          <% users.each do |user| %>
-            <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-              <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
-            </li>
-          <% end %>
+          <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">ルート結果</a>
+          </li>
         </ul>
       </div>
     </div>
-    <% users.each do |user| %>
+
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
         <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
           <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
@@ -32,6 +30,6 @@
           </table>
         </div>
       </div>
-    <% end %>
+
   </div>
 </div>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -22,12 +22,32 @@
                 <th class="md:w-[100px]"></th>
               </tr>
             </thead>
-            <tbody id="ranking-table">
+            <tbody id="course-table">
+              <tr id="start-location">
+                <td></td>
+                <td>  
+                  <%= render 'spots/modal', spot: start_location %>
+                </td>
+                <td>
+                  出発地
+                </td>
+                <td></td>
+              </tr>
               <% ranking_spots.each_with_index do |spot, index| %>
                 <% spot_subscribers[spot.id].each do |user| %>
                   <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user } %>
                 <% end %>
               <% end %>
+              <tr id="end-location">
+                <td></td>
+                <td>  
+                  <%= render 'spots/modal', spot: end_location %>
+                </td>
+                <td>
+                  到着地
+                </td>
+                <td></td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -22,11 +22,13 @@
                 <th class="md:w-[100px]"></th>
               </tr>
             </thead>
-              <tbody id="spot-table-<%= user.id %>">
-                <% user_spots[user.id].each do |spot| %>
-                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user: user } %>
+            <tbody id="ranking-table">
+              <% ranking_spots.each_with_index do |spot, index| %>
+                <% spot_subscribers[spot.id].each do |user| %>
+                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user } %>
                 <% end %>
-              </tbody>
+              <% end %>
+            </tbody>
           </table>
         </div>
       </div>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -1,0 +1,37 @@
+<div class="m-5">
+  <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-xl bg-primary">
+    <div class="flex overflow-x-auto">
+      <div class="flex-none">
+        <ul class="list-reset flex">
+          <% users.each do |user| %>
+            <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+              <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl"><%= user.name %></a>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+    <% users.each do |user| %>
+      <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">
+        <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
+          <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]"></th>
+              </tr>
+            </thead>
+              <tbody id="spot-table-<%= user.id %>">
+                <% user_spots[user.id].each do |spot| %>
+                  <%= render partial: 'spots/spot', locals: { spot: spot, plan: plan, user: user } %>
+                <% end %>
+              </tbody>
+          </table>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/courses/_spot.html.erb
+++ b/app/views/courses/_spot.html.erb
@@ -1,0 +1,16 @@
+<tr id="spot-<%= spot.id %>">
+  <td></td>
+  <td>  
+    <%= render 'spots/modal', spot: spot %>
+  </td>
+  <td>
+    <%= link_to "#", class:"hover:brightness-75" do %>
+      <div class="avatar">
+          <div class="rounded-full mx-2 md:mx-auto w-7 h-7 md:w-12 md:h-12">
+            <%= image_tag user.avatar_url, alt:"Avatar" %>
+          </div>
+      </div>
+    <% end %>
+  </td>
+  <td></td>
+</tr>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -5,7 +5,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, spot_counter: @spot_counter %>
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,0 +1,19 @@
+<article class="pb-4 flex flex-col justify-center">
+  <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7">プランのルート</h2>
+
+  <!-- 地図の表示 -->
+  <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
+
+  <!-- 登録済みリスト -->
+  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, spot_counter: @spot_counter %>
+
+  <!-- 削除ボタン -->
+  <div class="flex justify-around mt-3">
+    <% if current_user.present? && current_user.id === @plan.owner_id %>
+      <%= link_to t('.destroy'), plan_path(@plan), class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
+    <% end %>
+
+    <!-- 一覧ページボタン --> 
+    <%= link_to t('.back_index'), plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+  </div>
+</article>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -5,7 +5,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, plan: @plan %>
+  <%= render 'list', ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, plan: @plan, start_location: @start_location, end_location: @end_location %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">
@@ -14,6 +14,6 @@
     <% end %>
 
     <!-- 一覧ページボタン --> 
-    <%= link_to t('.back_index'), plans_path, class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to 'プラン詳細', plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 </article>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,5 +1,5 @@
 <article class="pb-4 flex flex-col justify-center">
-  <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7">プランのルート</h2>
+  <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7"><%= @plan.name %>当日のルート</h2>
 
   <!-- 地図の表示 -->
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -5,7 +5,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers %>
+  <%= render 'list', ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, plan: @plan %>
 
   <!-- 削除ボタン -->
   <div class="flex justify-around mt-3">

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -39,7 +39,7 @@
           </tbody>
         </table>
       </div>
-      <div data-controller="modal">
+      <!--<div data-controller="modal">
         <div class="flex justify-center pt-2">
           <%= render template: 'courses/new' %>
           <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
@@ -49,7 +49,7 @@
             ルート作成
           <% end %>
         </div>
-      </div>
+      </div>-->
     </div>
     <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -39,7 +39,7 @@
           </tbody>
         </table>
       </div>
-      <!--<div data-controller="modal">
+      <div data-controller="modal">
         <div class="flex justify-center pt-2">
           <%= render template: 'courses/new' %>
           <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
@@ -49,7 +49,7 @@
             ルート作成
           <% end %>
         </div>
-      </div>-->
+      </div>
     </div>
     <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">

--- a/db/migrate/20240531043106_create_courses.rb
+++ b/db/migrate/20240531043106_create_courses.rb
@@ -4,7 +4,6 @@ class CreateCourses < ActiveRecord::Migration[7.1]
       t.string :start_location, null: false
       t.string :end_location, null: false
       t.references :plan, null: false, foreign_key: true
-      t.references :planned_spot, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,11 +18,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_043106) do
     t.string "start_location", null: false
     t.string "end_location", null: false
     t.bigint "plan_id", null: false
-    t.bigint "planned_spot_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["plan_id"], name: "index_courses_on_plan_id"
-    t.index ["planned_spot_id"], name: "index_courses_on_planned_spot_id"
   end
 
   create_table "members", force: :cascade do |t|
@@ -107,7 +105,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_043106) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "courses", "planned_spots"
   add_foreign_key "courses", "plans"
   add_foreign_key "members", "plans"
   add_foreign_key "members", "users"


### PR DESCRIPTION
### 概要
コースの詳細ページ作成

### 実装ページ
![e2c09b1b7cea25b35ff10ef4b95ecc0f](https://github.com/maru973/Tripot_Share/assets/148407473/9477efbd-a33a-4b79-bca7-4519143bf1f0)


### 内容
- [x] コーステーブルの保存
- [x] 出発地、到着地とランキングのスポットをリストに一括表示  


### 補足
現在showページのマップは未実装のため非表示。
courseテーブルにあったplanned_spot_idと紐づけてしまうと、同じstart_location, end_locationを持ったデータが複数作成されてしまうため、不要と判断し削除。