### PR TITLE
【feature】スポットリストをルート検索の結果順に表示 close #226

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -66,6 +66,7 @@ class CoursesController < ApplicationController
   end
 
   def update_order
+    @plan = Course.find(params[:id]).plan
     # JSのルート検索で出てきた結果のplace_idを取得
     place_ids = params[:place_ids]
 
@@ -82,7 +83,6 @@ class CoursesController < ApplicationController
         end
       end
     end
-    head :ok # 成功時のレスポンス
   end
 
   private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -79,7 +79,7 @@ class CoursesController < ApplicationController
       if spot
         planned_spot = PlannedSpot.find_by(spot_id: spot.id)
         if planned_spot
-          planned_spot.update(position: index + 1) # 1から始まる位置にするためにindexに1を足す
+          planned_spot.update(position: index + 1) # 1から始めるためにindexに1を足す
         end
       end
     end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -17,6 +17,15 @@ class CoursesController < ApplicationController
       @start_location.latitude = @latlng[0]
       @start_location.longitude = @latlng[1]
       @start_location.address = results.first.address
+
+      spot_details = @start_location.get_spot_details(@course.start_location)
+      if spot_details
+        @start_location.place_id = spot_details[:place_id]
+        @start_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+        @start_location.website = spot_details[:website]
+        @start_location.phone_number = spot_details[:phone_number]
+      end
+
       @start_location.save
     end
     if @end_location.new_record?
@@ -25,6 +34,15 @@ class CoursesController < ApplicationController
       @end_location.latitude = @latlng[0]
       @end_location.longitude = @latlng[1]
       @end_location.address = results.first.address
+
+      spot_details = @end_location.get_spot_details(@course.end_location)
+      if spot_details
+        @end_location.place_id = spot_details[:place_id]
+        @end_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+        @end_location.website = spot_details[:website]
+        @end_location.phone_number = spot_details[:phone_number]
+      end
+
       @end_location.save
     end
     @course.save

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -11,42 +11,45 @@ class CoursesController < ApplicationController
     @course = @plan.courses.build(course_params)
     @start_location = Spot.find_or_initialize_by(name: @course.start_location)
     @end_location = Spot.find_or_initialize_by(name: @course.end_location)
-    if @start_location.new_record?
-      results = Geocoder.search(@course.start_location)
-      @latlng = results.first.coordinates
-      @start_location.latitude = @latlng[0]
-      @start_location.longitude = @latlng[1]
-      @start_location.address = results.first.address
+    
+    if @course.start_location.present? && @course.end_location.present?
+      if @start_location.new_record?
+        results = Geocoder.search(@course.start_location)
+        @latlng = results.first.coordinates
+        @start_location.latitude = @latlng[0]
+        @start_location.longitude = @latlng[1]
+        @start_location.address = results.first.address
 
-      spot_details = @start_location.get_spot_details(@course.start_location)
-      if spot_details
-        @start_location.place_id = spot_details[:place_id]
-        @start_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
-        @start_location.website = spot_details[:website]
-        @start_location.phone_number = spot_details[:phone_number]
+        spot_details = @start_location.get_spot_details(@course.start_location)
+        if spot_details
+          @start_location.place_id = spot_details[:place_id]
+          @start_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+          @start_location.website = spot_details[:website]
+          @start_location.phone_number = spot_details[:phone_number]
+        end
+
+        @start_location.save
       end
+      if @end_location.new_record?
+        results = Geocoder.search(@course.end_location)
+        @latlng = results.first.coordinates
+        @end_location.latitude = @latlng[0]
+        @end_location.longitude = @latlng[1]
+        @end_location.address = results.first.address
 
-      @start_location.save
-    end
-    if @end_location.new_record?
-      results = Geocoder.search(@course.end_location)
-      @latlng = results.first.coordinates
-      @end_location.latitude = @latlng[0]
-      @end_location.longitude = @latlng[1]
-      @end_location.address = results.first.address
+        spot_details = @end_location.get_spot_details(@course.end_location)
+        if spot_details
+          @end_location.place_id = spot_details[:place_id]
+          @end_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+          @end_location.website = spot_details[:website]
+          @end_location.phone_number = spot_details[:phone_number]
+        end
 
-      spot_details = @end_location.get_spot_details(@course.end_location)
-      if spot_details
-        @end_location.place_id = spot_details[:place_id]
-        @end_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
-        @end_location.website = spot_details[:website]
-        @end_location.phone_number = spot_details[:phone_number]
+        @end_location.save
       end
-
-      @end_location.save
+      @course.save
+      redirect_to course_path(@course), notice: 'コースを作成しました'
     end
-    @course.save
-    redirect_to course_path(@course), notice: 'コースを作成しました'
   end
 
   def show
@@ -58,7 +61,9 @@ class CoursesController < ApplicationController
 
     spot_ids = @spot_points.keys
     spots = Spot.where(id: spot_ids)
-    @ranking_spots = spot_ids.map { |id| spots.find { |spot| spot.id == id } }
+    @ranking_spots = Spot.joins(:planned_spots)
+    .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
+    .order('planned_spots.position')
 
     @ranking_spots.each do |spot|
       @spot_subscribers[spot.id] = User.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, spot_id: spot.id })
@@ -77,10 +82,8 @@ class CoursesController < ApplicationController
     place_ids.each_with_index do |place_id, index|
       spot = Spot.find_by(place_id: place_id)
       if spot
-        planned_spot = PlannedSpot.find_by(spot_id: spot.id)
-        if planned_spot
-          planned_spot.update(position: index + 1) # 1から始めるためにindexに1を足す
-        end
+        planned_spot = PlannedSpot.find_by(spot_id: spot.id, plan_id: @plan.id)
+        planned_spot.update(position: index + 1) # 1から始めるためにindexに1を足す
       end
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -30,7 +30,7 @@ class CoursesController < ApplicationController
 
         @start_location.save
       end
-      if @end_location.new_record?
+      if @course.end_location.present? && @end_location.new_record?
         results = Geocoder.search(@course.end_location)
         @latlng = results.first.coordinates
         @end_location.latitude = @latlng[0]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -62,8 +62,8 @@ class CoursesController < ApplicationController
     spot_ids = @spot_points.keys
     spots = Spot.where(id: spot_ids)
     @ranking_spots = Spot.joins(:planned_spots)
-    .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
-    .order('planned_spots.position')
+      .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
+      .order('planned_spots.position')
 
     @ranking_spots.each do |spot|
       @spot_subscribers[spot.id] = User.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, spot_id: spot.id })

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -70,7 +70,7 @@ class CoursesController < ApplicationController
     end
   end
 
-  def update_order
+  def update_position
     @plan = Course.find(params[:id]).plan
     # JSのルート検索で出てきた結果のplace_idを取得
     place_ids = params[:place_ids]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -65,6 +65,26 @@ class CoursesController < ApplicationController
     end
   end
 
+  def update_order
+    # JSのルート検索で出てきた結果のplace_idを取得
+    place_ids = params[:place_ids]
+
+    # 配列の最初(出発地のplace_id)と最後(到着地のplace_id)を削除
+    place_ids.shift
+    place_ids.pop
+    
+    place_ids.each_with_index do |place_id, index|
+      spot = Spot.find_by(place_id: place_id)
+      if spot
+        planned_spot = PlannedSpot.find_by(spot_id: spot.id)
+        if planned_spot
+          planned_spot.update(position: index + 1) # 1から始まる位置にするためにindexに1を足す
+        end
+      end
+    end
+    head :ok # 成功時のレスポンス
+  end
+
   private
 
   def course_params

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -19,6 +19,7 @@ class SpotsController < ApplicationController
 
           spot_details = @spot.get_spot_details(spot_params[:name])
           if spot_details
+            @spot.place_id = spot_details[:place_id]
             @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
             @spot.website = spot_details[:website]
             @spot.phone_number = spot_details[:phone_number]

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -24,6 +24,7 @@ class Spot < ApplicationRecord
 
     spot_details = @client.spot(place_id, fields: 'place_id,opening_hours,website,formatted_phone_number', language: 'ja')
     {
+      place_id: spot_details.place_id,
       opening_hours: spot_details.opening_hours&.[]('weekday_text'),
       website: spot_details.website ? spot_details.website : nil,
       phone_number: spot_details.formatted_phone_number ? spot_details.formatted_phone_number : nil

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -56,11 +56,34 @@
     };
 
     directionsService.route(request, function(result, status) {
-      if (status === 'OK') {
-        directionsRenderer.setDirections(result);
-        console.log(result);
-      }
-    });
+    if (status === 'OK') {
+      directionsRenderer.setDirections(result);
+      console.log(result.geocoded_waypoints);
+
+      // place_idの配列を抽出
+      const placeIds = result.geocoded_waypoints.map(waypoint => waypoint.place_id);
+
+      console.log(placeIds);
+
+      // RailsにPOSTリクエストを送信
+      fetch('/courses/update_order', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+        },
+        body: JSON.stringify({ place_ids: placeIds })
+      })
+      .then(response => {
+        if (response.ok) {
+          console.log("Place IDs sent successfully");
+        } else {
+          console.error("Failed to send Place IDs");
+        }
+      });
+    } else {
+      console.error('Directions request failed due to ' + status);
+    }});
   }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places,marker&v=weekly" async defer></script>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -68,7 +68,7 @@
       console.log(placeIds);
 
       // RailsにPOSTリクエストを送信
-      fetch('/courses/<%= @course.id %>/update_order', {
+      fetch('/courses/<%= @course.id %>/update_position', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -39,17 +39,19 @@
 
     // 経由地の配列を生成（最大6個）
     let wayPoints = new Array();
-    let waypoint_string = '<%= raw @ranking_spots.map { |spot| { lat: spot.latitude, lng: spot.longitude } }.to_json %>'
+    let waypoint_string = '<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>'
     let waypoint_array = JSON.parse(waypoint_string);
 
     waypoint_array.forEach(function(waypoint_element) {
-      wayPoints.push({location: waypoint_element});
+      wayPoints.push({location: { placeId: waypoint_element.place_id } });
     });
+
+    console.log(wayPoints);
 
     // ルートを取得するリクエスト
     let request = {
-      origin: new google.maps.LatLng(<%= @start_location.latitude %>, <%= @start_location.longitude %>),      // スタート地点
-      destination: new google.maps.LatLng(<%= @end_location.latitude %>, <%= @end_location.longitude %>),   // ゴール地点
+      origin: { placeId: '<%= @start_location.place_id %>' },      // スタート地点
+      destination: { placeId: '<%= @end_location.place_id %>' },   // ゴール地点
       travelMode: google.maps.TravelMode.DRIVING, // 車モード
       optimizeWaypoints: true, // 最適化を有効
       waypoints: wayPoints // 経由地
@@ -58,7 +60,7 @@
     directionsService.route(request, function(result, status) {
     if (status === 'OK') {
       directionsRenderer.setDirections(result);
-      console.log(result.geocoded_waypoints);
+      console.log(result);
 
       // place_idの配列を抽出
       const placeIds = result.geocoded_waypoints.map(waypoint => waypoint.place_id);

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -68,7 +68,7 @@
       console.log(placeIds);
 
       // RailsにPOSTリクエストを送信
-      fetch('/courses/update_order', {
+      fetch('/courses/<%= @course.id %>/update_order', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :courses, only: %i[show] do
     member do
-      post :update_order
+      post :update_position
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,10 @@ Rails.application.routes.draw do
   get 'myplans', to: 'mypages#myplans'
   get 'mycourses', to: 'mypages#mycourses'
 
+  resources :courses, only: %i[show] do
+    collection do
+      post :update_order
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
   get 'mycourses', to: 'mypages#mycourses'
 
   resources :courses, only: %i[show] do
-    collection do
+    member do
       post :update_order
     end
   end

--- a/db/migrate/20240605022249_add_place_id_to_spots.rb
+++ b/db/migrate/20240605022249_add_place_id_to_spots.rb
@@ -1,0 +1,6 @@
+class AddPlaceIdToSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :spots, :place_id, :string
+    add_index :spots, :place_id, unique: true
+  end
+end

--- a/db/migrate/20240605095113_add_position_to_planned_spots.rb
+++ b/db/migrate/20240605095113_add_position_to_planned_spots.rb
@@ -1,0 +1,5 @@
+class AddPositionToPlannedSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :planned_spots, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_05_022249) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_095113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_022249) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "position"
     t.index ["plan_id"], name: "index_planned_spots_on_plan_id"
     t.index ["spot_id"], name: "index_planned_spots_on_spot_id"
     t.index ["user_id"], name: "index_planned_spots_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_043106) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_022249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,6 +75,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_043106) do
     t.string "opening_hours"
     t.string "phone_number"
     t.string "website"
+    t.string "place_id"
+    t.index ["place_id"], name: "index_spots_on_place_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### 概要
スポットリストをルート検索の結果順に表示

### 実装ページ
![9175828bc784a0ac52778822fdda5dcd](https://github.com/maru973/Tripot_Share/assets/148407473/11c1584b-af0b-4695-990d-bfb32ad81285)


### 内容
- [x] Spotsテーブルにplace_idのカラムを追加
- [x] ルート検索時に緯度経度からplace_idを使用する方法に変更 
- [x] JSコードで取得した結果からplace_idをrailsのコントローラーに送信
- [x] planned_spotsテーブルにpositionカラムを追加
- [x] リクエスト用のパスにcourse_idを付与 


### 補足
現在showページではリロードをしないと正しい順番でリストが表示されないので今後のタスクで修正。