### PR TITLE
【feature】並び替え機能の実装 close #39

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,5 +76,6 @@ gem 'google_places'
 gem 'carrierwave'
 gem 'fog-aws'
 gem 'ransack'
+gem 'ranked-model'
 
 gem "dockerfile-rails", ">= 1.6", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    ranked-model (0.4.9)
+      activerecord (>= 5.2)
     ransack (4.1.1)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
@@ -380,6 +382,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-i18n
+  ranked-model
   ransack
   sprockets-rails
   stimulus-rails

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -63,7 +63,7 @@ class CoursesController < ApplicationController
     spots = Spot.where(id: spot_ids)
     @ranking_spots = Spot.joins(:planned_spots)
       .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
-      .order('planned_spots.position')
+      .order('planned_spots.row_order')
 
     @ranking_spots.each do |spot|
       @spot_subscribers[spot.id] = User.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, spot_id: spot.id })
@@ -83,7 +83,7 @@ class CoursesController < ApplicationController
       spot = Spot.find_by(place_id: place_id)
       if spot
         planned_spot = PlannedSpot.find_by(spot_id: spot.id, plan_id: @plan.id)
-        planned_spot.update(position: index + 1) # 1から始めるためにindexに1を足す
+        planned_spot.update(row_order: index + 1) # 1から始めるためにindexに1を足す
       end
     end
   end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("hello", HelloController)
 
 import RemovalsController from "./removals_controller"
 application.register("removals", RemovalsController)
+
+import SortableController from "./sortable_controller"
+application.register("sortable", SortableController)

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -3,9 +3,16 @@ import Sortable from "sortablejs"
 
 // Connects to data-controller="sortable"
 export default class extends Controller {
+  static values = {
+    handleSelector: String,
+  }
   connect() {
     const options = {
-      onEnd: this.onEnd.bind(this)
+      onEnd: this.onEnd.bind(this),
+      ghostClass: "bg-gray-300",
+    }
+    if (this.hasHandleSelectorValue) {
+      options.handle = this.handleSelectorValue
     }
     Sortable.create(this.element, options)
   }

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+import Sortable from "sortablejs"
+
+// Connects to data-controller="sortable"
+export default class extends Controller {
+  connect() {
+    const options = {
+      onEnd: this.onEnd.bind(this)
+    }
+    Sortable.create(this.element, options)
+  }
+ 
+  onEnd(evt) {
+    const body = { row_order_position: evt.newIndex }
+    console.log(body)
+  }
+}

--- a/app/models/planned_spot.rb
+++ b/app/models/planned_spot.rb
@@ -1,4 +1,7 @@
 class PlannedSpot < ApplicationRecord
+  include RankedModel
+  ranks :row_order
+
   belongs_to :plan
   belongs_to :spot
   belongs_to :user

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -22,7 +22,7 @@
                 <th class="md:w-[100px]"></th>
               </tr>
             </thead>
-            <tbody id="course-table" data-controller="sortable">
+            <tbody id="course-table" data-controller="sortable" data-sortable-handle-selector-value=".sortable-handle">
               <tr id="start-location">
                 <td></td>
                 <td>  
@@ -33,7 +33,7 @@
                 </td>
                 <td></td>
               </tr>
-              <% ranking_spots.each_with_index do |spot, index| %>
+              <% ranking_spots.each do |spot| %>
                 <% spot_subscribers[spot.id].each do |user| %>
                   <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user } %>
                 <% end %>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -22,7 +22,7 @@
                 <th class="md:w-[100px]"></th>
               </tr>
             </thead>
-            <tbody id="course-table">
+            <tbody id="course-table" data-controller="sortable">
               <tr id="start-location">
                 <td></td>
                 <td>  

--- a/app/views/courses/_spot.html.erb
+++ b/app/views/courses/_spot.html.erb
@@ -1,5 +1,9 @@
 <tr id="spot-<%= spot.id %>">
-  <td></td>
+  <td class="sortable-handle cursor-grab">
+    <span class="material-symbols-outlined">
+      drag_handle
+    </span>
+  </td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -7,13 +7,8 @@
   <!-- 登録済みリスト -->
   <%= render 'list', ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, plan: @plan, start_location: @start_location, end_location: @end_location %>
 
-  <!-- 削除ボタン -->
-  <div class="flex justify-around mt-3">
-    <% if current_user.present? && current_user.id === @plan.owner_id %>
-      <%= link_to t('.destroy'), plan_path(@plan), class:"text-base-content btn btn-error btn-sm md:btn-lg", data: {turbo_method: :delete, turbo_confirm: "#{@plan.name}を削除しますか" } %>
-    <% end %>
-
-    <!-- 一覧ページボタン --> 
+  <!-- 一覧ページボタン --> 
+  <div class="flex justify-center mt-3">
     <%= link_to 'プラン詳細', plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 </article>

--- a/db/migrate/20240606085135_rename_position_column_to_plannedspots.rb
+++ b/db/migrate/20240606085135_rename_position_column_to_plannedspots.rb
@@ -1,0 +1,5 @@
+class RenamePositionColumnToPlannedspots < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :planned_spots, :position, :row_order
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_05_095113) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_085135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,7 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_095113) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.integer "position"
+    t.integer "row_order"
     t.index ["plan_id"], name: "index_planned_spots_on_plan_id"
     t.index ["spot_id"], name: "index_planned_spots_on_spot_id"
     t.index ["user_id"], name: "index_planned_spots_on_user_id"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "daisyui": "^4.10.1",
     "esbuild": "^0.20.2",
     "postcss": "^8.4.38",
+    "sortablejs": "^1.15.2",
     "tailwindcss": "^3.4.3",
     "tailwindcss-stimulus-components": "^5.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,6 +816,11 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+sortablejs@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.2.tgz#4e9f7bda4718bd1838add9f1866ec77169149809"
+  integrity sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA==
+
 source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"


### PR DESCRIPTION
### 概要
並び替え機能の実装

### 実装ページ
![841d51cb0f1f5f077b8474cbd3c8a55d](https://github.com/maru973/Tripot_Share/assets/148407473/eaf3fe3e-2f74-4b5e-8b38-4deccac813a5)


### 内容
- [x] アイコン部分で並び替え
- [x] positionカラムをrow_orderカラムにリネーム
- [x] gem ranked-modelの追加 
- [x]  sortablejsの追加


### 補足
出発地と到着地は並び替えで動かせないが、他の動かせるスポットを上に持ってきたりはできてしまうため今後修正予定。