### PR TITLE
【feature】並び替え後のルート再検索 close #230

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,5 @@
 class CoursesController < ApplicationController
-  before_action :point_calculate, only: [:show]
+  before_action :point_calculate, only: [:show, :new_ordered_spots]
 
   def new
     @plan = Plan.find(params[:plan_id])
@@ -12,44 +12,42 @@ class CoursesController < ApplicationController
     @start_location = Spot.find_or_initialize_by(name: @course.start_location)
     @end_location = Spot.find_or_initialize_by(name: @course.end_location)
     
-    if @course.start_location.present? && @course.end_location.present?
-      if @start_location.new_record?
-        results = Geocoder.search(@course.start_location)
-        @latlng = results.first.coordinates
-        @start_location.latitude = @latlng[0]
-        @start_location.longitude = @latlng[1]
-        @start_location.address = results.first.address
+    if @course.start_location.present? && @start_location.new_record?
+      results = Geocoder.search(@course.start_location)
+      @latlng = results.first.coordinates
+      @start_location.latitude = @latlng[0]
+      @start_location.longitude = @latlng[1]
+      @start_location.address = results.first.address
+      spot_details = @start_location.get_spot_details(@course.start_location)
 
-        spot_details = @start_location.get_spot_details(@course.start_location)
-        if spot_details
-          @start_location.place_id = spot_details[:place_id]
-          @start_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
-          @start_location.website = spot_details[:website]
-          @start_location.phone_number = spot_details[:phone_number]
-        end
-
-        @start_location.save
+      if spot_details
+        @start_location.place_id = spot_details[:place_id]
+        @start_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+        @start_location.website = spot_details[:website]
+        @start_location.phone_number = spot_details[:phone_number]
       end
-      if @course.end_location.present? && @end_location.new_record?
-        results = Geocoder.search(@course.end_location)
-        @latlng = results.first.coordinates
-        @end_location.latitude = @latlng[0]
-        @end_location.longitude = @latlng[1]
-        @end_location.address = results.first.address
-
-        spot_details = @end_location.get_spot_details(@course.end_location)
-        if spot_details
-          @end_location.place_id = spot_details[:place_id]
-          @end_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
-          @end_location.website = spot_details[:website]
-          @end_location.phone_number = spot_details[:phone_number]
-        end
-
-        @end_location.save
-      end
-      @course.save
-      redirect_to course_path(@course), notice: 'コースを作成しました'
+      @start_location.save
     end
+
+    if @course.end_location.present? && @end_location.new_record?
+      results = Geocoder.search(@course.end_location)
+      @latlng = results.first.coordinates
+      @end_location.latitude = @latlng[0]
+      @end_location.longitude = @latlng[1]
+      @end_location.address = results.first.address
+      spot_details = @end_location.get_spot_details(@course.end_location)
+
+      if spot_details
+        @end_location.place_id = spot_details[:place_id]
+        @end_location.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
+        @end_location.website = spot_details[:website]
+        @end_location.phone_number = spot_details[:phone_number]
+      end
+      @end_location.save
+    end
+
+    @course.save
+    redirect_to course_path(@course), notice: 'コースを作成しました'
   end
 
   def show
@@ -87,6 +85,19 @@ class CoursesController < ApplicationController
       end
     end
     redirect_to course_path(params[:id])
+  end
+
+  def new_ordered_spots
+    @course = Course.find(params[:id])
+    @plan = @course.plan
+
+    spot_ids = @spot_points.keys
+    spots = Spot.where(id: spot_ids)
+    @ranking_spots = Spot.joins(:planned_spots)
+      .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
+      .order('planned_spots.row_order')
+
+    render json: @ranking_spots.map { |spot| { place_id: spot.place_id } }
   end
 
   def rank

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -88,6 +88,13 @@ class CoursesController < ApplicationController
     end
   end
 
+  def rank
+    plan = Course.find(params[:id]).plan
+    spot = Spot.find(params[:spot_id])
+    planned_spot = PlannedSpot.find_by(spot_id: spot.id, plan_id: plan.id)
+    planned_spot.update(row_order: params[:row_order_position])
+  end
+
   private
 
   def course_params

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -68,7 +68,7 @@ class CoursesController < ApplicationController
     end
   end
 
-  def update_position
+  def create_position
     @plan = Course.find(params[:id]).plan
     # JSのルート検索で出てきた結果のplace_idを取得
     place_ids = params[:place_ids]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -86,6 +86,7 @@ class CoursesController < ApplicationController
         planned_spot.update(row_order: index + 1) # 1から始めるためにindexに1を足す
       end
     end
+    redirect_to course_path(params[:id])
   end
 
   def rank

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,5 @@
 class CoursesController < ApplicationController
-  before_action :point_calculate, only: [:show, :new_ordered_spots]
+  before_action :point_calculate, only: [:show, :reserach_course]
 
   def new
     @plan = Plan.find(params[:plan_id])
@@ -87,7 +87,7 @@ class CoursesController < ApplicationController
     redirect_to course_path(params[:id])
   end
 
-  def new_ordered_spots
+  def reserach_course
     @course = Course.find(params[:id])
     @plan = @course.plan
 

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -21,31 +21,6 @@ export default class extends Controller {
     const body = { 
       row_order_position: evt.newIndex,
       spot_id: evt.item.dataset.spotId
-     }
-    fetch(evt.item.dataset.sortableUrl, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-        'Accept': 'text/vnd.turbo-stream.html'  // Turbo Streamのレスポンスを受け入れる
-      },
-      body: JSON.stringify(body)
-    })
-    .then(response => {
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
-      }
-      return response.text();  // Turbo StreamはHTMLとして返される
-    })
-    .then(turboStream => {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(turboStream, 'text/html');
-      doc.body.querySelectorAll('turbo-stream').forEach(stream => {
-        document.documentElement.appendChild(stream);
-      });
-    })
-    .catch(error => {
-      console.error('There has been a problem with your fetch operation:', error);
-    });
-  }
+    }
+  };
 }

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -18,7 +18,34 @@ export default class extends Controller {
   }
  
   onEnd(evt) {
-    const body = { row_order_position: evt.newIndex }
-    console.log(body)
+    const body = { 
+      row_order_position: evt.newIndex,
+      spot_id: evt.item.dataset.spotId
+     }
+    fetch(evt.item.dataset.sortableUrl, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        'Accept': 'text/vnd.turbo-stream.html'  // Turbo Streamのレスポンスを受け入れる
+      },
+      body: JSON.stringify(body)
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.text();  // Turbo StreamはHTMLとして返される
+    })
+    .then(turboStream => {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(turboStream, 'text/html');
+      doc.body.querySelectorAll('turbo-stream').forEach(stream => {
+        document.documentElement.appendChild(stream);
+      });
+    })
+    .catch(error => {
+      console.error('There has been a problem with your fetch operation:', error);
+    });
   }
 }

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -35,7 +35,7 @@
               </tr>
               <% ranking_spots.each do |spot| %>
                 <% spot_subscribers[spot.id].each do |user| %>
-                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user } %>
+                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user, course: course } %>
                 <% end %>
               <% end %>
               <tr id="end-location">

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -52,7 +52,7 @@
           </table>
         </div>
           <div class="flex justify-center pt-2">
-            <button id="re-search-button" class="text-base-content btn btn-primary btn-sm md:btn-lg">再検索</button>
+            <button id="research-button" class="text-base-content btn btn-primary btn-sm md:btn-lg">再検索</button>
           </div>
       </div>
 

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -4,7 +4,7 @@
       <div class="flex-none">
         <ul class="list-reset flex">
           <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">ルート結果</a>
+            <a class="text-xs md:text-lg inline-block px-2 md:py-2 md:px-4 rounded-t-xl">検索結果</a>
           </li>
         </ul>
       </div>
@@ -51,6 +51,9 @@
             </tbody>
           </table>
         </div>
+          <div class="flex justify-center pt-2">
+            <button id="re-search-button" class="text-base-content btn btn-primary btn-sm md:btn-lg">再検索</button>
+          </div>
       </div>
 
   </div>

--- a/app/views/courses/_spot.html.erb
+++ b/app/views/courses/_spot.html.erb
@@ -1,4 +1,4 @@
-<tr id="spot-<%= spot.id %>">
+<tr id="spot-<%= spot.id %>" data-sortable-url="<%= rank_course_path(course) %>" data-spot-id="<%= spot.id %>">
   <td class="sortable-handle cursor-grab">
     <span class="material-symbols-outlined">
       drag_handle

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -9,7 +9,7 @@
     </div>
     <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center">ルートの作成</h2>
     <p class="text-xs md:text-sm text-center">ランクインしたスポットを出発地から到着地まで<br />効率よく巡ることができるルートを自動で作成します</p>
-    <%= form_with model: @course, url: plan_courses_path(@plan), data: {turbo_method: :post} do |f|%>
+    <%= form_with model: @course, url: plan_courses_path(@plan), id: "form", data: {turbo_method: :post} do |f|%>
       <%= render 'shared/error_messages', object: f.object %>
       <div class="form-control my-3">
         <%= f.label :start_location %>
@@ -27,3 +27,11 @@
     <% end %>
   </dialog>
 <% end %>
+
+<script>
+
+  document.getElementById('form').addEventListener('submit', function(event) {
+    sessionStorage.setItem('first_load', 'true'); 
+  });
+
+</script>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -29,9 +29,7 @@
 <% end %>
 
 <script>
-
   document.getElementById('form').addEventListener('submit', function(event) {
     sessionStorage.setItem('first_load', 'true'); 
   });
-
 </script>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -9,6 +9,7 @@
 
   <!-- 一覧ページボタン --> 
   <div class="flex justify-center mt-3">
+    <button id="re-search-button">再検索</button>
     <%= link_to 'プラン詳細', plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 </article>
@@ -32,55 +33,64 @@
     //directionsRenderer と地図を紐付け
     directionsRenderer.setMap(map);
 
-    // 経由地の配列を生成（最大6個）
+    // wayPointsの初期化
     let wayPoints = new Array();
-    let waypoint_string = '<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>'
-    let waypoint_array = JSON.parse(waypoint_string);
-
-    waypoint_array.forEach(function(waypoint_element) {
-      wayPoints.push({location: { placeId: waypoint_element.place_id } });
-    });
 
     console.log(wayPoints);
 
-    // ルートを取得するリクエスト
-    let request = {
-      origin: { placeId: '<%= @start_location.place_id %>' },      // スタート地点
-      destination: { placeId: '<%= @end_location.place_id %>' },   // ゴール地点
-      travelMode: google.maps.TravelMode.DRIVING, // 車モード
-      optimizeWaypoints: true, // 最適化を有効
-      waypoints: wayPoints // 経由地
-    };
+    function searchRoute(wayPoints, optimizeWaypoints) {
+      // ルートを取得するリクエスト
+      let request = {
+        origin: { placeId: '<%= @start_location.place_id %>' },      // スタート地点
+        destination: { placeId: '<%= @end_location.place_id %>' },   // ゴール地点
+        travelMode: google.maps.TravelMode.DRIVING, // 車モード
+        optimizeWaypoints: optimizeWaypoints, // 最適化を有効
+        waypoints: wayPoints // 経由地
+      };
 
-    directionsService.route(request, function(result, status) {
-    if (status === 'OK') {
-      directionsRenderer.setDirections(result);
-      console.log(result);
+      directionsService.route(request, function(result, status) {
+        if (status === 'OK') {
+          directionsRenderer.setDirections(result);
+          console.log(result);
 
-      // place_idの配列を抽出
-      const placeIds = result.geocoded_waypoints.map(waypoint => waypoint.place_id);
+          // place_idの配列を抽出
+          const placeIds = result.geocoded_waypoints.map(waypoint => waypoint.place_id);
 
-      console.log(placeIds);
+          console.log(placeIds);
 
-      // RailsにPOSTリクエストを送信
-      fetch('/courses/<%= @course.id %>/update_position', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-        },
-        body: JSON.stringify({ place_ids: placeIds })
-      })
-      .then(response => {
-        if (response.ok) {
-          console.log("Place IDs sent successfully");
+          // RailsにPOSTリクエストを送信
+          fetch('/courses/<%= @course.id %>/update_position', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+            },
+            body: JSON.stringify({ place_ids: placeIds })
+          })
+          .then(response => {
+            if (response.ok) {
+              console.log("Place IDs sent successfully");
+            } else {
+              console.error("Failed to send Place IDs");
+            }
+          });
         } else {
-          console.error("Failed to send Place IDs");
+          console.error('Directions request failed due to ' + status);
         }
       });
-    } else {
-      console.error('Directions request failed due to ' + status);
-    }});
+    }
+    let initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
+    searchRoute(initialWayPoints, true);
+
+    // 再検索ボタンにクリックイベントを追加
+    document.getElementById('re-search-button').addEventListener('click', function() {
+      fetch('/courses/<%= @course.id %>/new_ordered_spots')
+        .then(response => response.json())
+        .then(data => {
+          const newWayPoints = data.map(spot => ({ location: { placeId: spot.place_id } }));
+          searchRoute(newWayPoints, false);
+        });
+    });
   }
 </script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLEMAPS_API_KEY']%>&callback=initMap&libraries=places,marker&v=weekly" async defer></script>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -59,7 +59,7 @@
           console.log(placeIds);
 
           // RailsにPOSTリクエストを送信
-          fetch('/courses/<%= @course.id %>/update_position', {
+          fetch('/courses/<%= @course.id %>/create_position', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -92,8 +92,8 @@
     }
 
     // 再検索ボタンにクリックイベントを追加
-    document.getElementById('re-search-button').addEventListener('click', function() {
-      fetch('/courses/<%= @course.id %>/new_ordered_spots')
+    document.getElementById('research-button').addEventListener('click', function() {
+      fetch('/courses/<%= @course.id %>/reserach_course')
         .then(response => response.json())
         .then(data => {
           const newWayPoints = data.map(spot => ({ location: { placeId: spot.place_id } }));

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,5 +1,6 @@
 <article class="pb-4 flex flex-col justify-center">
-  <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7"><%= @plan.name %>当日のルート</h2>
+  <h2 class="grow text-xl md:text-2xl font-bold underline mt-1 md:mt-2 text-center ps-7"><%= @plan.name %>当日のルート</h2>
+  <p class="grow text-lg md:text-xl font-bold underline mb-1 md:mb-2 text-center ps-7">（スポットを並び替えてルートを再検索できます）</p>
 
   <!-- 地図の表示 -->
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
@@ -9,7 +10,6 @@
 
   <!-- 一覧ページボタン --> 
   <div class="flex justify-center mt-3">
-    <button id="re-search-button">再検索</button>
     <%= link_to 'プラン詳細', plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 </article>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -79,19 +79,17 @@
         }
       });
     }
+
     const isFirstLoad = sessionStorage.getItem('first_load');
 
-if (isFirstLoad) {
-  const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
-  searchRoute(initialWayPoints, true); // 初回ロード時は最適化を有効
-  sessionStorage.removeItem('first_load');
-} else {
-  const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
-  searchRoute(initialWayPoints, false); // 最適化を無効
-}
-      
-
-
+    if (isFirstLoad) {
+      const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
+      searchRoute(initialWayPoints, true); // 初回ロード時は最適化を有効
+      sessionStorage.removeItem('first_load');
+    } else {
+      const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
+      searchRoute(initialWayPoints, false); // 最適化を無効
+    }
 
     // 再検索ボタンにクリックイベントを追加
     document.getElementById('re-search-button').addEventListener('click', function() {

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -79,14 +79,17 @@
         }
       });
     }
-    const isFirstLoad = !sessionStorage.getItem('page_loaded');
+    const isFirstLoad = sessionStorage.getItem('first_load');
+
+if (isFirstLoad) {
+  const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
+  searchRoute(initialWayPoints, true); // 初回ロード時は最適化を有効
+  sessionStorage.removeItem('first_load');
+} else {
+  const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
+  searchRoute(initialWayPoints, false); // 最適化を無効
+}
       
-      if (isFirstLoad) {
-        sessionStorage.setItem('page_loaded', 'true');
-      }
-      
-    const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
-    searchRoute(initialWayPoints, isFirstLoad); // 初回ロード時は最適化を有効
 
 
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -5,7 +5,7 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 登録済みリスト -->
-  <%= render 'list', ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, plan: @plan, start_location: @start_location, end_location: @end_location %>
+  <%= render 'list', ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, plan: @plan, start_location: @start_location, end_location: @end_location, course: @course %>
 
   <!-- 一覧ページボタン --> 
   <div class="flex justify-center mt-3">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -41,10 +41,10 @@
     function searchRoute(wayPoints, optimizeWaypoints) {
       // ルートを取得するリクエスト
       let request = {
-        origin: { placeId: '<%= @start_location.place_id %>' },      // スタート地点
-        destination: { placeId: '<%= @end_location.place_id %>' },   // ゴール地点
+        origin: { placeId: '<%= @start_location.place_id %>' },
+        destination: { placeId: '<%= @end_location.place_id %>' },
         travelMode: google.maps.TravelMode.DRIVING, // 車モード
-        optimizeWaypoints: optimizeWaypoints, // 最適化を有効
+        optimizeWaypoints: optimizeWaypoints, // 最適化を有効か無効にする
         waypoints: wayPoints // 経由地
       };
 
@@ -79,8 +79,16 @@
         }
       });
     }
-    let initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
-    searchRoute(initialWayPoints, true);
+    const isFirstLoad = !sessionStorage.getItem('page_loaded');
+      
+      if (isFirstLoad) {
+        sessionStorage.setItem('page_loaded', 'true');
+      }
+      
+    const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
+    searchRoute(initialWayPoints, isFirstLoad); // 初回ロード時は最適化を有効
+
+
 
     // 再検索ボタンにクリックイベントを追加
     document.getElementById('re-search-button').addEventListener('click', function() {

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -39,7 +39,7 @@
           </tbody>
         </table>
       </div>
-      <!--<div data-controller="modal">
+      <div data-controller="modal">
         <div class="flex justify-center pt-2">
           <%= render template: 'courses/new' %>
           <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
@@ -49,7 +49,7 @@
             ルート作成
           <% end %>
         </div>
-      </div>-->
+      </div>
     </div>
     <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :courses, only: %i[show] do
     member do
-      post :update_position
+      post :create_position
       patch :rank
       get :reserach_course
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
     member do
       post :update_position
       patch :rank
-      get :new_ordered_spots
+      get :reserach_course
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   resources :courses, only: %i[show] do
     member do
       post :update_position
+      patch :rank
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
     member do
       post :update_position
       patch :rank
+      get :new_ordered_spots
     end
   end
 


### PR DESCRIPTION
### 概要
並び替え後のルート再検索

### 実装ページ
![a2b16ecd6e0bc1c3c11ac92607ba85e2](https://github.com/maru973/Tripot_Share/assets/148407473/30107ebe-68b8-45f1-887f-b93b23f49fe0)
![67f20aa1c322cd6ee12904bb81704d64](https://github.com/maru973/Tripot_Share/assets/148407473/8026eb18-2548-432f-b978-bcb9fbbbf69f)


### 内容
- [x] ルートを再検索した際、最適化を適用しない
- [x] セッションストレージにフォームを送信したら値を渡し、showページで削除  
- [x] 並び替えごとにrow_orderをアップデート 


### 補足
row_orderが並び替えるとマイナスになるバグが出ているので、後のタスクで修正。