### PR TITLE
【feature】ルートを作成していればルートの詳細にいくボタンを設置

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -65,12 +65,7 @@ class PlansController < ApplicationController
     @spots = @plan.spots
     @user_spots = {}
     @spot_subscribers = {}
-
-    @course = @plan.course
-
-    unless @course.present?
-      @course = Course.new
-    end
+    @course = Course.new
 
     # @spot_poinsのキー(spot_id)を使って並び替え
     spot_ids = @spot_points.keys

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -65,7 +65,12 @@ class PlansController < ApplicationController
     @spots = @plan.spots
     @user_spots = {}
     @spot_subscribers = {}
-    @course = Course.new
+
+    @course = @plan.course
+
+    unless @course.present?
+      @course = Course.new
+    end
 
     # @spot_poinsのキー(spot_id)を使って並び替え
     spot_ids = @spot_points.keys

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -4,7 +4,7 @@ class Plan < ApplicationRecord
   belongs_to :owner, class_name: 'User', foreign_key: 'owner_id'
   has_many :members, dependent: :destroy
   has_many :users, through: :members
-  has_many :courses, dependent: :destroy
+  has_one :course, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 100 }
   validates :location, presence: true

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -39,17 +39,23 @@
           </tbody>
         </table>
       </div>
-      <div data-controller="modal">
+      <% if plan.course.present? %>
         <div class="flex justify-center pt-2">
-          <%= render template: 'courses/new' %>
-          <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
-            <span class="material-symbols-outlined">
-              route
-            </span>
-            ルート作成
-          <% end %>
+          <%= link_to "このプランのルートを確認", course_path(plan.course), class:"text-base-content btn btn-primary btn-sm md:btn-lg" %>
+        <div>
+      <% else %>
+        <div data-controller="modal">
+          <div class="flex justify-center pt-2">
+            <%= render template: 'courses/new' %>
+            <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
+              <span class="material-symbols-outlined">
+                route
+              </span>
+              ルート作成
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
     <% users.each do |user| %>
       <div class="hidden py-4 px-4 border bg-base-100 rounded-box rounded-tl-none" data-tabs-target="panel">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -26,7 +26,7 @@
             <% end %>
           </li>
 
-          <!--<li class="text-xs md:text-lg">
+          <li class="text-xs md:text-lg">
             <div class="md:tooltip md:tooltip-left md:tooltip-accent" data-tip="登録したスポットの行きたい度合いを選択して投票しよう！メンバーが投票した結果を集計してランキングをつくるよ！">
               <%= link_to plan_spot_points_path(@plan), data: { turbo: false } do %>
                 <span class= "material-symbols-outlined" style= "font-size: 20px;">
@@ -35,7 +35,7 @@
                 ランキング投票
               <% end %>
             </div>
-          </li>-->
+          </li>
 
           <li class="text-xs md:text-lg">
             <div data-controller="modal">


### PR DESCRIPTION
### 概要
ルートを作成していればルートの詳細にいくボタンを設置

### 実装ページ
<img width="1428" alt="410b74b749e94413a789d8978afa908d" src="https://github.com/maru973/Tripot_Share/assets/148407473/33525e25-889a-4c1c-9ab0-685d719966d6">


### 内容
- [x] プランとルートのアソシエーションを一対一に変更 
- [x] ルートがすでに存在すれば詳細ページへのボタンを設置 
