### PR TITLE
【bug】ルートの再計算ができないバグ修正 close #234

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -8,7 +8,7 @@ class CoursesController < ApplicationController
 
   def create
     @plan = Plan.find(params[:plan_id])
-    @course = @plan.courses.build(course_params)
+    @course = @plan.create_course(course_params)
     @start_location = Spot.find_or_initialize_by(name: @course.start_location)
     @end_location = Spot.find_or_initialize_by(name: @course.end_location)
     

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -22,5 +22,30 @@ export default class extends Controller {
       row_order_position: evt.newIndex,
       spot_id: evt.item.dataset.spotId
     }
+    fetch(evt.item.dataset.sortableUrl, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        'Accept': 'text/vnd.turbo-stream.html'  // Turbo Streamのレスポンスを受け入れる
+      },
+      body: JSON.stringify(body)
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.text();  // Turbo StreamはHTMLとして返される
+    })
+    .then(turboStream => {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(turboStream, 'text/html');
+      doc.body.querySelectorAll('turbo-stream').forEach(stream => {
+        document.documentElement.appendChild(stream);
+      });
+    })
+    .catch(error => {
+      console.error('There has been a problem with your fetch operation:', error);
+    });
   };
 }

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -41,7 +41,7 @@
       </div>
       <% if plan.course.present? %>
         <div class="flex justify-center pt-2">
-          <%= link_to "このプランのルートを確認", course_path(plan.course), class:"text-base-content btn btn-primary btn-sm md:btn-lg" %>
+          <%= link_to "このプランのルートを確認", course_path(plan.course), class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { turbo: false } %>
         <div>
       <% else %>
         <div data-controller="modal">


### PR DESCRIPTION
### 概要
ルートの再計算ができないバグ修正


### 内容
- [x] 初期検索以外は最適化をfalseにして並び順通りのルートを検索 
