### PR TITLE
【fix】ルートはプランのメンバーのみ作成できるようにする close #238

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -52,19 +52,23 @@ class CoursesController < ApplicationController
 
   def show
     @course = Course.find(params[:id])
-    @start_location = Spot.find_by(name: @course.start_location)
-    @end_location = Spot.find_by(name: @course.end_location)
+    if current_user.member?(@plan.id)
+      @start_location = Spot.find_by(name: @course.start_location)
+      @end_location = Spot.find_by(name: @course.end_location)
 
-    @spot_subscribers = {}
+      @spot_subscribers = {}
 
-    spot_ids = @spot_points.keys
-    spots = Spot.where(id: spot_ids)
-    @ranking_spots = Spot.joins(:planned_spots)
-      .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
-      .order('planned_spots.row_order')
+      spot_ids = @spot_points.keys
+      spots = Spot.where(id: spot_ids)
+      @ranking_spots = Spot.joins(:planned_spots)
+        .where(id: spot_ids, planned_spots: { plan_id: @plan.id })
+        .order('planned_spots.row_order')
 
-    @ranking_spots.each do |spot|
-      @spot_subscribers[spot.id] = User.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, spot_id: spot.id })
+      @ranking_spots.each do |spot|
+        @spot_subscribers[spot.id] = User.joins(:planned_spots).where(planned_spots: { plan_id: @plan.id, spot_id: spot.id })
+      end
+    else
+      redirect_to plan_path(@plan), alert: 'あなたはこのプランのメンバーではないためこのページは開けません'
     end
   end
 

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -39,22 +39,24 @@
           </tbody>
         </table>
       </div>
-      <% if plan.course.present? %>
-        <div class="flex justify-center pt-2">
-          <%= link_to "このプランのルートを確認", course_path(plan.course), class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { turbo: false } %>
-        <div>
-      <% else %>
-        <div data-controller="modal">
+      <% if current_user.present? && current_user.member?(plan.id) %>
+        <% if plan.course.present? %>
           <div class="flex justify-center pt-2">
-            <%= render template: 'courses/new' %>
-            <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
-              <span class="material-symbols-outlined">
-                route
-              </span>
-              ルート作成
-            <% end %>
+            <%= link_to "このプランのルートを確認", course_path(plan.course), class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { turbo: false } %>
+          <div>
+        <% else %>
+          <div data-controller="modal">
+            <div class="flex justify-center pt-2">
+              <%= render template: 'courses/new' %>
+              <%= link_to new_plan_course_path(plan), data: { action: "click->modal#open", turbo_frame: "course" }, class:"text-base-content btn btn-primary btn-sm md:btn-lg", data: { action: "click->modal#open", turbo_frame: "course" } do %>
+                <span class="material-symbols-outlined">
+                  route
+                </span>
+                ルート作成
+              <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
     </div>
     <% users.each do |user| %>

--- a/app/views/spot_points/index.html.erb
+++ b/app/views/spot_points/index.html.erb
@@ -12,7 +12,7 @@
 
   <!-- 一覧ページボタン --> 
   <div class="flex justify-around mt-3">
-    <%= link_to t('.back_index'), plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to "プラン詳細", plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
   </div>
 </article>
 


### PR DESCRIPTION
### 概要
ルートはプランのメンバーのみ作成できるようにする

### 実装ページ
![80d608006ed980d81866023d1d640d08](https://github.com/maru973/Tripot_Share/assets/148407473/082b6a7e-e21f-4e22-9653-b8aae7d08ffb)


### 内容
- [x] ルート作成ボタンはメンバーのみ表示
- [x] メンバー以外が直接ルートの詳細ページのパスを入力してもプラン詳細ページに遷移 
