### PR TITLE
【bug】ページをリロードしなくてもオートコンプリートが実行される close #198

### DIFF
--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -35,12 +35,22 @@
       mapId: "<%= ENV['GOOGLE_MAP_ID'] %>"
     });
 
-    // const input = document.getElementById("pac-input");
-    // const options = {
-    //   fields: ["address_components", "name"],
-    // };
-    // const autocomplete = new google.maps.places.Autocomplete(input, options);
-    // autocomplete.bindTo("bounds", map);
+    const input = document.getElementById("pac-input");
+    const options = {
+      fields: ["address_components", "name"],
+    };
+    const autocomplete = new google.maps.places.Autocomplete(input, options);
+    autocomplete.bindTo("bounds", map);
+
+    autocomplete.addListener("place_changed", function() {
+    const place = autocomplete.getPlace();
+    if (!place.name || !place.name.length) {
+      return; // 名前がない場合や長さが0の場合は処理しない
+    }
+    // 太字の部分（スポット名）だけを取得してフォームにセット
+    const spotName = place.name;
+      document.getElementById("spot_name_input").value = spotName;
+    });
 
     // ページリロードしても登録したマーカーが消えない設定
     <% @spots.each do |spot| %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -2,6 +2,8 @@
   <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
     <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
       <%= f.text_field :name, id:"pac-input", class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
+      <!-- JSコードで処理したスポット名だけを取得 -->
+      <%= f.hidden_field :name, id: "spot_name_input" %>
       <%= f.submit "登録", class:"text-base-content btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>
     </div>
   <% end %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -8,3 +8,25 @@
     </div>
   <% end %>
 </div>
+
+<script>
+  function initAutocomplete() {
+    const input = document.getElementById("pac-input");
+    const options = {
+      fields: ["address_components", "name"],
+    };
+    const autocomplete = new google.maps.places.Autocomplete(input, options);
+    autocomplete.bindTo("bounds", map);
+
+    autocomplete.addListener("place_changed", function() {
+      const place = autocomplete.getPlace();
+      if (!place.name || !place.name.length) {
+        return; // 名前がない場合や長さが0の場合は処理しない
+      }
+      // 太字の部分（スポット名）だけを取得してフォームにセット
+      const spotName = place.name;
+      document.getElementById("spot_name_input").value = spotName;
+    });
+  }
+  initAutocomplete();
+</script>


### PR DESCRIPTION
### 概要
ページをリロードしなくてもオートコンプリートが実行される

### 実装ページ
![c5eaba9a738884197493442a9fa84a77](https://github.com/maru973/Tripot_Share/assets/148407473/2377e9fa-d022-4fbc-8c04-b5a3fc43d325)


### 内容
- [x] ページをリロードしなくてもオートコンプリートが実行される
- [x] オートコンプリートででた選択肢をクリックしても住所がnameに入らず、スポット名を保存  
