### PR TITLE
【fix】フォームのサイズ調整

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -10,7 +10,7 @@
 
   <!-- 一覧ページボタン --> 
   <div class="flex justify-center mt-3">
-    <%= link_to 'プラン詳細', plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg" %>
+    <%= link_to 'プラン詳細', plan_path(@plan), class:"text-base-content btn btn-accent btn-sm md:btn-lg", data: { turbo: false } %>
   </div>
 </article>
 

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,7 +1,7 @@
 <div id="spot-form">
   <%= form_with model: spot, url: plan_spots_path(plan) do |f|%>
-    <div class="flex mx-auto md:mx-20 my-3 border rounded-lg"> 
-      <%= f.text_field :name, id:"pac-input", class:"input input-sm md:input-lg w-full max-w-xs md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
+    <div class="flex mx-5 md:mx-20 my-3 border rounded-lg"> 
+      <%= f.text_field :name, id:"pac-input", class:"input input-sm md:input-lg w-full md:max-w-full rounded-none rounded-l-lg", placeholder:"スポット名を入力してね" %>
       <!-- JSコードで処理したスポット名だけを取得 -->
       <%= f.hidden_field :name, id: "spot_name_input" %>
       <%= f.submit "登録", class:"text-base-content btn btn-secondary btn-sm md:btn-lg rounded-none rounded-r-lg" %>


### PR DESCRIPTION
### 概要
フォームのサイズ調整

### 内容
- [x] スマホ画面のフォームサイズを調整
- [x] ルート詳細にあったプラン詳細へ戻るボタンにdata: { turbo: false }を追加
