### PR TITLE
【fix】スポット情報をマップ上のウィンドウから表示できるように修正 close #246

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -50,14 +50,20 @@
 
       directionsService.route(request, function(result, status) {
         if (status === 'OK') {
-          directionsRenderer.setDirections(result);
-          console.log(result);
+          console.log(result.routes[0].legs[6]);
+          result.routes[0].legs[0].start_address = '出発地：<%= j render 'spots/modal', spot: @start_location %>';
+          result.routes[0].legs[6].end_address = '到着地：<%= j render 'spots/modal', spot: @end_location %>';
+
+          <% @ranking_spots.each_with_index do |spot, index| %>
+            result.routes[0].legs[<%= index + 1 %>].start_address = '<%= j render 'spots/modal', spot: spot %>';
+          <% end %>  
 
           // place_idの配列を抽出
           const placeIds = result.geocoded_waypoints.map(waypoint => waypoint.place_id);
 
           console.log(placeIds);
 
+          directionsRenderer.setDirections(result);
           // RailsにPOSTリクエストを送信
           fetch('/courses/<%= @course.id %>/create_position', {
             method: 'POST',
@@ -81,13 +87,12 @@
     }
 
     const isFirstLoad = sessionStorage.getItem('first_load');
+    const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
 
     if (isFirstLoad) {
-      const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
       searchRoute(initialWayPoints, true); // 初回ロード時は最適化を有効
       sessionStorage.removeItem('first_load');
     } else {
-      const initialWayPoints = JSON.parse('<%= raw @ranking_spots.map { |spot| { place_id: spot.place_id } }.to_json %>').map(spot => ({ location: { placeId: spot.place_id } }));
       searchRoute(initialWayPoints, false); // 最適化を無効
     }
 

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -79,7 +79,7 @@
             <tbody id="spot-table-<%= user.id %>">
               <% user_spots[user.id].each_with_index do |spot, index| %>
                 <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
-                <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'user' } %>
+                <%= render partial: 'spots/spot_point', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'user' } %>
               <% end %>
             </tbody>
           </table>

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -72,7 +72,7 @@
           
         });
 
-        const contentString = '<div id="infowindow"><%= j render 'spots/modal', spot: spot %></div>';
+        const contentString = '<div><%= j render 'spots/modal', spot: spot %></div>';
     
         let infowindow = new google.maps.InfoWindow({
           content: contentString,

--- a/app/views/plans/new_spots.html.erb
+++ b/app/views/plans/new_spots.html.erb
@@ -72,6 +72,13 @@
           
         });
 
+        const contentString = '<div id="infowindow"><%= j render 'spots/modal', spot: spot %></div>';
+    
+        let infowindow = new google.maps.InfoWindow({
+          content: contentString,
+          ariaLabel: '<%= spot.name %>',
+        });
+
         let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
@@ -79,6 +86,29 @@
         });
         marker.id = <%= spot.id %>;
         markers.push(marker);
+
+        marker.addListener("click", () => {
+          infowindow.open({
+            anchor: marker,
+            map,
+          });
+        });
+
+        // リストのスポット名をクリックするとマップの情報ウィンドウが開く
+        let open_infowindow = document.getElementById('infowindow-<%= spot.id %>')
+        if (open_infowindow) {
+          open_infowindow.addEventListener('click', () => {
+            infowindow.open({
+              anchor: marker,
+              map,
+            });
+          });
+        }
+
+        // ウィンドウ以外の場所をクリックしてウィンドウを閉じる処理
+        google.maps.event.addListener(map, 'click', function() {
+          infowindow.close();
+        });
       })();
     <% end %>
   }

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -109,7 +109,7 @@
           glyph: glyphImg,
           
         });
-        const contentString = '<div id="infowindow"><%= j render 'spots/modal', spot: spot %></div>';
+        const contentString = '<div><%= j render 'spots/modal', spot: spot %></div>';
     
         let infowindow = new google.maps.InfoWindow({
           content: contentString,

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -109,6 +109,12 @@
           glyph: glyphImg,
           
         });
+        const contentString = '<div><%= j render 'spots/modal', spot: spot %></div>';
+    
+        let infowindow = new google.maps.InfoWindow({
+          content: contentString,
+          ariaLabel: '<%= spot.name %>',
+        });
 
         let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
@@ -117,6 +123,27 @@
         });
         marker.id = <%= spot.id %>;
         markers.push(marker);
+
+        marker.addListener("click", () => {
+          infowindow.open({
+            anchor: marker,
+            map,
+          });
+        });
+
+        // リストのスポット名をクリックするとマップの情報ウィンドウが開く
+        let open_infowindow = document.getElementById('open-infowindow-<%= spot.id %>')
+        open_infowindow.addEventListener('click', () => {
+          infowindow.open({
+            anchor: marker,
+            map,
+          });
+        });
+
+        // ウィンドウ以外の場所をクリックしてウィンドウを閉じる処理
+        google.maps.event.addListener(map, 'click', function() {
+          infowindow.close();
+        });
       })();
     <% end %>
   }

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -109,7 +109,7 @@
           glyph: glyphImg,
           
         });
-        const contentString = '<div><%= j render 'spots/modal', spot: spot %></div>';
+        const contentString = '<div id="infowindow"><%= j render 'spots/modal', spot: spot %></div>';
     
         let infowindow = new google.maps.InfoWindow({
           content: contentString,
@@ -132,13 +132,26 @@
         });
 
         // リストのスポット名をクリックするとマップの情報ウィンドウが開く
-        let open_infowindow = document.getElementById('open-infowindow-<%= spot.id %>')
-        open_infowindow.addEventListener('click', () => {
-          infowindow.open({
-            anchor: marker,
-            map,
+        let open_infowindow = document.getElementById('infowindow-<%= spot.id %>')
+        if (open_infowindow) {
+          open_infowindow.addEventListener('click', () => {
+            infowindow.open({
+              anchor: marker,
+              map,
+            });
           });
-        });
+        }
+
+        let rank_infowindow = document.getElementById('rank-infowindow-<%= spot.id %>')
+        if (rank_infowindow) {
+          rank_infowindow.addEventListener('click', () => {
+            infowindow.open({
+              anchor: marker,
+              map,
+            });
+          });
+        }
+
 
         // ウィンドウ以外の場所をクリックしてウィンドウを閉じる処理
         google.maps.event.addListener(map, 'click', function() {

--- a/app/views/spot_points/_spot.html.erb
+++ b/app/views/spot_points/_spot.html.erb
@@ -1,7 +1,10 @@
 <tr id="spot-<%= spot.id %>">
   <td></td>
   <td>  
-    <%= render 'spots/modal', spot: spot %>
+    <div id="infowindow-<%= spot.id %>" class="link link-hover">
+      <div class="text-md md:text-lg"><%= spot.name %></div>
+      <div class="text-xs md:text-sm opacity-50 truncate"><%= spot.address %></div>
+    </div>
   </td>
   <td>
     <%= link_to "#", class:"hover:brightness-75" do %>

--- a/app/views/spot_points/index.html.erb
+++ b/app/views/spot_points/index.html.erb
@@ -53,6 +53,13 @@
           
         });
 
+        const contentString = '<div><%= j render 'spots/modal', spot: spot %></div>';
+    
+        let infowindow = new google.maps.InfoWindow({
+          content: contentString,
+          ariaLabel: '<%= spot.name %>',
+        });
+
         let marker = new google.maps.marker.AdvancedMarkerElement({
           map: map,
           position: {lat: <%= spot.latitude %>, lng: <%= spot.longitude %>},
@@ -60,6 +67,29 @@
         });
         marker.id = <%= spot.id %>;
         markers.push(marker);
+
+        marker.addListener("click", () => {
+          infowindow.open({
+            anchor: marker,
+            map,
+          });
+        });
+
+        // リストのスポット名をクリックするとマップの情報ウィンドウが開く
+        let open_infowindow = document.getElementById('infowindow-<%= spot.id %>')
+        if (open_infowindow) {
+          open_infowindow.addEventListener('click', () => {
+            infowindow.open({
+              anchor: marker,
+              map,
+            });
+          });
+        }
+
+        // ウィンドウ以外の場所をクリックしてウィンドウを閉じる処理
+        google.maps.event.addListener(map, 'click', function() {
+          infowindow.close();
+        });
       })();
     <% end %>
   }

--- a/app/views/spots/_modal.html.erb
+++ b/app/views/spots/_modal.html.erb
@@ -5,7 +5,7 @@
   </div>
   <dialog data-modal-target="dialog" class="max-w-[500px] p-6 rounded-lg backdrop:bg-black/50 text-base-content">
     <div class="flex justify-end">
-      <button autofocus data-action="modal#close">
+      <button data-action="modal#close">
         <span class="material-symbols-outlined">
           close
         </span>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,7 +1,10 @@
 <tr id="spot-<%= spot.id %>">
   <td></td>
   <td>  
-    <%= render 'spots/modal', spot: spot %>
+    <div id="infowindow-<%= spot.id %>" class="link link-hover">
+      <div class="text-md md:text-lg"><%= spot.name %></div>
+      <div class="text-xs md:text-sm opacity-50 truncate"><%= spot.address %></div>
+    </div>
   </td>
   <td>
     <%= link_to "#", class:"hover:brightness-75" do %>

--- a/app/views/spots/_spot_point.html.erb
+++ b/app/views/spots/_spot_point.html.erb
@@ -1,7 +1,7 @@
 <tr id="spot-<%= spot.id %>">
   <td><%= index + 1 %></td>
   <td>  
-    <div id="rank-infowindow-<%= spot.id %>" class="link link-hover">
+    <div id="infowindow-<%= spot.id %>" class="link link-hover">
       <div class="text-md md:text-lg"><%= spot.name %></div>
       <div class="text-xs md:text-sm opacity-50 truncate"><%= spot.address %></div>
     </div>

--- a/app/views/spots/_spot_rankig.html.erb
+++ b/app/views/spots/_spot_rankig.html.erb
@@ -1,7 +1,10 @@
 <tr id="spot-<%= spot.id %>">
   <td><%= index + 1 %></td>
   <td>  
-    <%= render 'spots/modal', spot: spot %>
+    <div id="open-infowindow-<%= spot.id %>" class="link link-hover">
+      <div class="text-md md:text-lg"><%= spot.name %></div>
+      <div class="text-xs md:text-sm opacity-50 truncate"><%= spot.address %></div>
+    </div>
   </td>
   <td>
       <div class="avatar hover:brightness-75">


### PR DESCRIPTION
### 概要
スポット情報をマップ上のウィンドウから表示できるように修正

### 実装ページ
![0e79af9aebb42fefd1e20598d1165663](https://github.com/maru973/Tripot_Share/assets/148407473/0c1c8ac3-1db7-4165-ac1e-4010444cf25a)


### 内容
- [x] スポットリストのスポット名をクリックするとマップで該当のウィンドウが開く
- [x] ウィンドウをクリックするとスポットの詳細が表示される  
- [x] 地図内のウィンドウ以外の場所をクリックすると開いてるウィンドウが閉じる 


### 補足
ルートの検索結果ページは他の仕様と違うため、暫定的にマーカーをクリックしてのみウィンドウが表示される。