### PR TITLE
【feature】初回でプラン詳細ページに遷移するとモーダルを表示 close #207

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 
     <!-- twitter card -->
     <% if Rails.env.production? %>
-      <meta name="twitter:card" content="summary">
+      <meta name="twitter:card" content="summary_large_image">
       <meta property="og:title" content="Tripot Share">
       <meta property="og:url" content="https://tripot-share.fly.dev" />
       <meta property="og:description" content="メンバーと行きたい場所を共有して、気軽にオリジナルな旅行プランをつくることができるサービスです。" />

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -39,7 +39,13 @@
             <% end %>
           </tbody>
           <% else %>
-            <p class="whitespace-nowrap text-sm md:text-lg md:text-center p-4 md:p-10">右上の追加メニューからランキング投票を<br class="md:hidden" />して行きたい順にランキングをつけよう！</p>
+            <p class="whitespace-nowrap text-sm md:text-lg md:text-center p-4 md:p-10">
+              右上の
+              <span class="material-symbols-outlined" style= "font-size: 18px;">
+                add_box
+              </span>
+              からランキング投票を<br class="md:hidden" />して行きたい順にランキングをつけよう！
+            </p>
           <% end %>
         </table>
       </div>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -33,7 +33,7 @@
         </div>
 
         <div class="flex justify-center mt-3">
-          <%= f.submit "次へ", class: "text-base-content btn btn-sm md:btn-md btn-accent", data: { turbo: false } %>
+          <%= f.submit "作成", class: "text-base-content btn btn-sm md:btn-md btn-accent", data: { turbo: false } %>
         </div>
       <% end %>
     </div>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,6 +1,6 @@
 <article class="pb-4 flex flex-col justify-center">
   <div class="flex items-center">
-    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-16 md:ps-10"><%= @plan.name %></h2>
+    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-12 md:ps-10"><%= @plan.name %></h2>
 
     <% if current_user.present? && current_user.member?(@plan.id) %>
       <div class="twitter mx-3 lg:tooltip" data-tip="Xに投稿する">
@@ -56,13 +56,19 @@
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
   <!-- 初回のみのモーダル -->
-  <div id="myModal" class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50 hidden">
-    <div class="bg-white p-6 rounded-lg shadow-lg w-80">
+  <div id="explanationModal" class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50 hidden">
+    <div class="bg-white p-6 rounded-lg shadow-lg">
       <span id="closeModal" class="float-right cursor-pointer material-symbols-outlined">
         close
       </span>
-      <p>作成したプランに早速メンバーを招待しよう！</p>
-      <p>下のリンク作成ボタンを押して招待リンクを作成して、旅行メンバーに送って招待しよう。</p>
+      <h2 class="text-lg md:text-xl font-bold mb-1 md:mb-4 underline text-center">プランに早速メンバーを<br class="md:hidden" />招待しよう！</h2>
+      <p>下のボタンを押して作成された招待リンクから、旅行メンバーをプランに招待できます。</p>
+      <p class="mb-3 text-sm md:text-base">※招待メールを送信したい場合は右上にある
+        <span class="material-symbols-outlined" style= "font-size: 18px;">
+          add_box
+        </span>
+        から「メンバー招待」を選択して、メールを送信してください。
+      </p>
       <%= turbo_frame_tag "invite-link" do %>
         <% if @invite_link.present? %>
           <%= render template: 'plans/invitation' %>
@@ -72,6 +78,14 @@
           </div>
         <% end %>
       <% end %>
+      <div class="divider"></div> 
+      <div class="twitter my-5 flex justify-center">
+        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}を作成しました！&hashtags=TripotShare", target: '_blank', class: "btn btn-sm md:btn-md" do %>
+          <i class="fa-brands fa-square-x-twitter fa-xl"></i>
+          投稿する
+        <% end %>
+      </div>
+      <p class="text-center">※Xに投稿ではメンバーの招待はできません。開発者が喜びます。</p>
     </div>
   </div>
 
@@ -107,7 +121,7 @@
   });
 
   function showModal() {
-    const modal = document.getElementById('myModal');
+    const modal = document.getElementById('explanationModal');
     modal.classList.remove('hidden');
     // モーダルが表示された後にローカルストレージに値を設定
     localStorage.setItem('explanationModal', 'true');

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -51,7 +51,7 @@
       </div>
     <% else %>
       <div class="twitter mx-3 md:tooltip md:tooltip-left md:tooltip-accent" data-tip="Xに投稿する">
-        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}をみたよ！&hashtags=TripotShare", target: '_blank' do %>
+        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}をみたよ！みんなもみてね！&hashtags=TripotShare", target: '_blank' do %>
           <i class="fa-brands fa-square-x-twitter fa-xl"></i>
         <% end %>
       </div>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -4,7 +4,7 @@
 
     <% if current_user.present? && current_user.member?(@plan.id) %>
       <div class="twitter mx-3 md:tooltip md:tooltip-left md:tooltip-accent" data-tip="Xに投稿する">
-        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}を作成しました！&hashtags=TripotShare", target: '_blank' do %>
+        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}のメンバーになりました！&hashtags=TripotShare", target: '_blank' do %>
           <i class="fa-brands fa-square-x-twitter fa-xl"></i>
         <% end %>
       </div>
@@ -86,7 +86,7 @@
       <% end %>
       <div class="divider"></div> 
       <div class="twitter my-5 flex justify-center">
-        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}を作成しました！&hashtags=TripotShare", target: '_blank', class: "btn btn-sm md:btn-md" do %>
+        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}のメンバーになりました！&hashtags=TripotShare", target: '_blank', class: "btn btn-sm md:btn-md" do %>
           <i class="fa-brands fa-square-x-twitter fa-xl"></i>
           投稿する
         <% end %>
@@ -113,7 +113,7 @@
 
 <script>
   // 他のファイルでも使用できるようにfunctionの外側で定義
-  let map
+  let map;
 
   let markers = [];
 
@@ -126,20 +126,21 @@
       if (!modalShown) {
         showModal();
       }
+      function showModal() {
+        const modal = document.getElementById('explanationModal');
+        modal.classList.remove('hidden');
+        // モーダルが表示された後にローカルストレージに値を設定
+        localStorage.setItem('explanationModal', 'true');
+      }
     });
 
-    function showModal() {
-      const modal = document.getElementById('explanationModal');
-      modal.classList.remove('hidden');
-      // モーダルが表示された後にローカルストレージに値を設定
-      localStorage.setItem('explanationModal', 'true');
-    }
 
     document.getElementById('closeModal').addEventListener('click', function() {
       const modal = document.getElementById('explanationModal');
       modal.classList.add('hidden');
     });
   <% end %>
+
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -85,7 +85,7 @@
           投稿する
         <% end %>
       </div>
-      <p class="text-center">※Xに投稿ではメンバーの招待はできません。開発者が喜びます。</p>
+      <p class="text-center">※Xへの投稿ではメンバーの招待はできません。開発者が喜びます。</p>
     </div>
   </div>
 
@@ -128,7 +128,7 @@
   }
 
   document.getElementById('closeModal').addEventListener('click', function() {
-    const modal = document.getElementById('myModal');
+    const modal = document.getElementById('explanationModal');
     modal.classList.add('hidden');
   });
 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,6 +1,6 @@
 <article class="pb-4 flex flex-col justify-center">
   <div class="flex items-center">
-    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-16 md:ps-7"><%= @plan.name %></h2>
+    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-16 md:ps-10"><%= @plan.name %></h2>
 
     <% if current_user.present? && current_user.member?(@plan.id) %>
       <div class="twitter mx-3 lg:tooltip" data-tip="Xに投稿する">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -55,6 +55,26 @@
   <!-- 地図の表示 -->
   <div id="map" class="border w-full h-[250px] md:h-[400px] mt-1"></div>
 
+  <!-- 初回のみのモーダル -->
+  <div id="myModal" class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50 hidden">
+    <div class="bg-white p-6 rounded-lg shadow-lg w-80">
+      <span id="closeModal" class="float-right cursor-pointer material-symbols-outlined">
+        close
+      </span>
+      <p>作成したプランに早速メンバーを招待しよう！</p>
+      <p>下のリンク作成ボタンを押して招待リンクを作成して、旅行メンバーに送って招待しよう。</p>
+      <%= turbo_frame_tag "invite-link" do %>
+        <% if @invite_link.present? %>
+          <%= render template: 'plans/invitation' %>
+        <% else %>
+          <div class="flex justify-center">
+            <%= button_to "リンクを生成", invitation_plan_path(params[:id]), class:"text-base-content btn btn-accent btn-sm md:btn-md" %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
   <!-- 登録済みリスト -->
   <%= render 'list_ranking', users: @users, user_spots: @user_spots, plan: @plan, spot_points: @spot_points, ranking_spots: @ranking_spots, spot_subscribers: @spot_subscribers, spot_counter: @spot_counter %>
 
@@ -78,6 +98,25 @@
   let markers = [];
 
   const baseUrl = '<%= request.base_url %>';
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const modalShown = localStorage.getItem('explanationModal');
+    if (!modalShown) {
+      showModal();
+    }
+  });
+
+  function showModal() {
+    const modal = document.getElementById('myModal');
+    modal.classList.remove('hidden');
+    // モーダルが表示された後にローカルストレージに値を設定
+    localStorage.setItem('explanationModal', 'true');
+  }
+
+  document.getElementById('closeModal').addEventListener('click', function() {
+    const modal = document.getElementById('myModal');
+    modal.classList.add('hidden');
+  });
 
   // マップの初期化設定
   function initMap() {

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -3,7 +3,7 @@
     <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-12 md:ps-10"><%= @plan.name %></h2>
 
     <% if current_user.present? && current_user.member?(@plan.id) %>
-      <div class="twitter mx-3 lg:tooltip" data-tip="Xに投稿する">
+      <div class="twitter mx-3 md:tooltip md:tooltip-left md:tooltip-accent" data-tip="Xに投稿する">
         <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}を作成しました！&hashtags=TripotShare", target: '_blank' do %>
           <i class="fa-brands fa-square-x-twitter fa-xl"></i>
         <% end %>
@@ -48,6 +48,12 @@
             </div>
           </li>
         </ul>
+      </div>
+    <% else %>
+      <div class="twitter mx-3 md:tooltip md:tooltip-left md:tooltip-accent" data-tip="Xに投稿する">
+        <%= link_to "https://twitter.com/intent/tweet?url=#{plan_url(@plan)}&text=#{@plan.name}をみたよ！&hashtags=TripotShare", target: '_blank' do %>
+          <i class="fa-brands fa-square-x-twitter fa-xl"></i>
+        <% end %>
       </div>
     <% end %>
   </div>
@@ -113,25 +119,27 @@
 
   const baseUrl = '<%= request.base_url %>';
 
-  document.addEventListener('DOMContentLoaded', function() {
-    const modalShown = localStorage.getItem('explanationModal');
-    if (!modalShown) {
-      showModal();
+  // プランに参加しているメンバーが初めて詳細ページを開くとき、説明モーダルを表示
+  <% if current_user.present? && current_user.member?(@plan.id) %>
+    document.addEventListener('DOMContentLoaded', function() {
+      const modalShown = localStorage.getItem('explanationModal');
+      if (!modalShown) {
+        showModal();
+      }
+    });
+
+    function showModal() {
+      const modal = document.getElementById('explanationModal');
+      modal.classList.remove('hidden');
+      // モーダルが表示された後にローカルストレージに値を設定
+      localStorage.setItem('explanationModal', 'true');
     }
-  });
 
-  function showModal() {
-    const modal = document.getElementById('explanationModal');
-    modal.classList.remove('hidden');
-    // モーダルが表示された後にローカルストレージに値を設定
-    localStorage.setItem('explanationModal', 'true');
-  }
-
-  document.getElementById('closeModal').addEventListener('click', function() {
-    const modal = document.getElementById('explanationModal');
-    modal.classList.add('hidden');
-  });
-
+    document.getElementById('closeModal').addEventListener('click', function() {
+      const modal = document.getElementById('explanationModal');
+      modal.classList.add('hidden');
+    });
+  <% end %>
   // マップの初期化設定
   function initMap() {
     map = new google.maps.Map(document.getElementById("map"), {

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,7 +1,6 @@
 <article class="pb-4 flex flex-col justify-center">
   <div class="flex items-center">
-    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-7"><%= @plan.name %></h2>
-
+    <h2 class="grow text-xl md:text-2xl font-bold underline my-1 md:my-2 text-center ps-16 md:ps-7"><%= @plan.name %></h2>
 
     <% if current_user.present? && current_user.member?(@plan.id) %>
       <div class="twitter mx-3 lg:tooltip" data-tip="Xに投稿する">
@@ -12,7 +11,7 @@
       <!-- 追加メニュー -->
       <div class="flex-none dropdown dropdown-end">
         <div tabindex="0" role="button" class="pt-1 md:pr-5">
-          <div class="material-symbols-outlined">
+          <div class="material-symbols-outlined" style= "font-size: 38px;">
             add_box
           </div>
         </div>


### PR DESCRIPTION
### 概要
初回でプラン詳細ページに遷移するとモーダルを表示

### 実装ページ
![cdb251b93db00947f41d53621c703a3b](https://github.com/maru973/Tripot_Share/assets/148407473/cec2297a-e9db-42eb-83d0-c7bf73af1890)


### 内容
- [x] 初回でプラン詳細ページを開いたときに、モーダルを表示
- [x] モーダルはメンバーになっているプランのみで表示
- [x] Xの投稿ボタンをメンバーになってないプランでも文言を変更して、追加   

