### PR TITLE
【feature】ルート順がリストからもわかる close #251

### DIFF
--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
   }
  
   onEnd(evt) {
+    this.updateOrder();
     const body = { 
       row_order_position: evt.newIndex,
       spot_id: evt.item.dataset.spotId
@@ -47,5 +48,17 @@ export default class extends Controller {
     .catch(error => {
       console.error('There has been a problem with your fetch operation:', error);
     });
-  };
+  }
+
+  // 順番を即時反映するメソッド
+  updateOrder() {
+    const rows = this.element.querySelectorAll('tr');
+    const validRows = Array.from(rows).filter(row => row.querySelector('.order'));
+    validRows.forEach((row, index) => {
+      const orderCell = row.querySelector('.order');
+      if (orderCell) {
+        orderCell.textContent = String.fromCharCode(66 + index); // B, C, D, E, F, Gのみを使って設定
+      }
+    });
+  }
 }

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -52,7 +52,9 @@ export default class extends Controller {
 
   // 順番を即時反映するメソッド
   updateOrder() {
+    // コードからすべてのtrタグを取得
     const rows = this.element.querySelectorAll('tr');
+    // 取得したtrタグの中からクラス名がorderのコードのみ取得
     const validRows = Array.from(rows).filter(row => row.querySelector('.order'));
     validRows.forEach((row, index) => {
       const orderCell = row.querySelector('.order');

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -16,37 +16,36 @@
             <thead>
               <tr>
                 <th class="md:w-[100px]"></th>
+                <th class="md:w-[100px]"></th>
                 <th>スポット名</th>
                 <th class="md:w-[100px]">登録者</th>
-                <th class="md:w-[100px]"></th>
-                <th class="md:w-[100px]"></th>
               </tr>
             </thead>
             <tbody id="course-table" data-controller="sortable" data-sortable-handle-selector-value=".sortable-handle">
               <tr id="start-location">
                 <td></td>
+                <td>A</td>
                 <td>  
                   <%= render 'spots/modal', spot: start_location %>
                 </td>
                 <td>
                   出発地
                 </td>
-                <td></td>
               </tr>
-              <% ranking_spots.each do |spot| %>
+              <% ranking_spots.each_with_index do |spot, index| %>
                 <% spot_subscribers[spot.id].each do |user| %>
-                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user, course: course } %>
+                  <%= render partial: 'spot', locals: { spot: spot, plan: plan, user: user, course: course, rank: (66 + index).chr } %>
                 <% end %>
               <% end %>
               <tr id="end-location">
                 <td></td>
+                <td>H</td>
                 <td>  
                   <%= render 'spots/modal', spot: end_location %>
                 </td>
                 <td>
                   到着地
                 </td>
-                <td></td>
               </tr>
             </tbody>
           </table>

--- a/app/views/courses/_spot.html.erb
+++ b/app/views/courses/_spot.html.erb
@@ -4,6 +4,7 @@
       drag_handle
     </span>
   </td>
+  <td class="order"><%= rank %></td>
   <td>  
     <%= render 'spots/modal', spot: spot %>
   </td>
@@ -16,5 +17,4 @@
       </div>
     <% end %>
   </td>
-  <td></td>
 </tr>


### PR DESCRIPTION
### 概要
ルート順がリストからもわかる

### 実装ページ
![0daac1f5320e919d1665619e096afb7f](https://github.com/maru973/Tripot_Share/assets/148407473/02cc8345-a721-44f7-bf68-8f5ddf1e212b)


### 内容
- [x] 並び替えと同時に、横の英文字も更新される 
- [x] 出発地と到着地は固定の英文字