### PR TITLE
【bug】ルート再検索した後に情報ウィンドウが切り替わらないバグ修正 close #259

### DIFF
--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -51,7 +51,7 @@
           </table>
         </div>
           <div class="flex justify-center pt-2">
-            <button id="research-button" class="text-base-content btn btn-primary btn-sm md:btn-lg">再検索</button>
+            <%= link_to "再検索", course_path(course), id: "research-button", class: "text-base-content btn btn-primary btn-sm md:btn-lg", data: { turbo: false } %>
           </div>
       </div>
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -50,7 +50,7 @@
 
       directionsService.route(request, function(result, status) {
         if (status === 'OK') {
-          console.log(result.routes[0].legs[6]);
+          console.log(result.routes[0]);
           result.routes[0].legs[0].start_address = '出発地：<%= j render 'spots/modal', spot: @start_location %>';
           result.routes[0].legs[6].end_address = '到着地：<%= j render 'spots/modal', spot: @end_location %>';
 


### PR DESCRIPTION
### 概要
ルート再検索した後に情報ウィンドウが切り替わらないバグ修正

### 補足
@ranking_spotsの中身が再検索ボタンを押しても更新がされなかった。
更新するために再検索ボタンを押したらページをリダイレクトするようにして情報を更新。