### PR TITLE
【fix】コントローラーの条件分岐をリファクタリング close #241

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -6,17 +6,20 @@ class CoursesController < ApplicationController
 
   def create
     @plan = Plan.find(params[:plan_id])
-    @course = @plan.create_course(course_params)
-
-    unless @course.start_location.present? && @course.end_location.present?
+    
+    if course_params.blank?
       return redirect_to plan_path(@plan), alert: 'ルートを作成できませんでした'
     end
-
+    
     @start_location = Spot.save_spot(course_params[:start_location])
     @end_location = Spot.save_spot(course_params[:end_location])
-
-    @course.save
-    redirect_to course_path(@course), notice: 'ルートを作成しました'
+    
+    if @start_location == false || @end_location == false
+      return redirect_to plan_path(@plan), alert: 'ルートを作成できませんでした'
+    else
+      @course = @plan.create_course(course_params)
+      redirect_to course_path(@course), notice: 'ルートを作成しました'
+    end
   end
 
   def show

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -6,10 +6,8 @@ class CoursesController < ApplicationController
 
   def create
     @plan = Plan.find(params[:plan_id])
-    
-    if course_params.blank?
-      return redirect_to plan_path(@plan), alert: 'ルートを作成できませんでした'
-    end
+
+    return redirect_to plan_path(@plan), alert: 'ルートを作成できませんでした' if course_params.blank?
     
     @start_location = Spot.save_spot(course_params[:start_location])
     @end_location = Spot.save_spot(course_params[:end_location])

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -133,7 +133,7 @@ class PlansController < ApplicationController
         session[:plan_id] = nil
         @plan.update(invitation_token: nil)
 
-        redirect_to plan_path(@plan), notice: t('defaults.flash_message.added', item: @plan.name)
+        redirect_to myplans_path, notice: t('defaults.flash_message.added', item: @plan.name)
 
       elsif user_signed_in? && current_user.member?(@plan.id)
         session[:plan_id] = nil

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -15,15 +15,7 @@ class PlansController < ApplicationController
     @plan.owner_id = current_user.id
     if @plan.save
       @plan.users << current_user
-      @location = Spot.find_or_initialize_by(name: @plan.location)
-      if @location.new_record?
-        results = Geocoder.search(@plan.location)
-        @latlng = results.first.coordinates
-        @location.latitude = @latlng[0]
-        @location.longitude = @latlng[1]
-        @location.address = results.first.address
-        @location.save
-      end
+      save_location(@plan.location)
       redirect_to new_spots_plan_path(@plan), notice: t('defaults.flash_message.created', item: @plan.name)
     else
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Plan.model_name.human)
@@ -155,5 +147,17 @@ class PlansController < ApplicationController
 
   def plan_params
     params.require(:plan).permit(:name, :start_date, :end_date, :invitation_token, :location)
+  end
+
+  def save_location(location_name)
+    @location = Spot.find_or_initialize_by(name: location_name)
+    return unless @location.new_record?
+  
+    results = Geocoder.search(location_name)
+    @latlng = results.first.coordinates
+    @location.latitude = @latlng[0]
+    @location.longitude = @latlng[1]
+    @location.address = results.first.address
+    @location.save
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -3,46 +3,25 @@ class SpotsController < ApplicationController
     @user = current_user
 
     respond_to do |format|
-      if spot_params[:name].blank?
+      case
+      when spot_params.blank? 
         format.turbo_stream do
           flash.now[:alert] = 'スポット名を入力してください'
           render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
         end
-      else
-        results = Geocoder.search(spot_params[:name])
-        if results.present?
-          @latlng = results.first.coordinates
-          @place_id = results.first.place_id
-          @spot = Spot.find_or_initialize_by(place_id: @place_id)
-          if @spot.new_record?
-            @spot.place_id = @place_id
-            @spot.name = spot_params[:name]
-            @spot.latitude = @latlng[0]
-            @spot.longitude = @latlng[1]
-            @spot.address = results.first.address
-
-            spot_details = @spot.get_spot_details(@place_id)
-            if spot_details
-              @spot.opening_hours = spot_details[:opening_hours].split(",").join("\n") if spot_details[:opening_hours].present?
-              @spot.website = spot_details[:website]
-              @spot.phone_number = spot_details[:phone_number]
-            end
-
-            @spot.save
-          end
-          @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
-          if @planned_spot.new_record?
-            @planned_spot.user_id = current_user.id
-            @planned_spot.save
-            format.turbo_stream { flash.now[:notice] = "スポットを登録しました" }
-          end
-          format.turbo_stream { flash.now[:alert] = "そのスポットはすでにプランに登録されています" }
-        else
-          format.turbo_stream do
-            flash.now[:alert] = 'スポットが見つかりませんでした'
-            render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
-          end
+      when (@spot = Spot.save_spot(spot_params)) == false
+        format.turbo_stream do
+          flash.now[:alert] = 'スポットが見つかりませんでした'
+          render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
         end
+      when @spot.present?
+        @planned_spot = PlannedSpot.find_or_initialize_by(plan_id: params[:plan_id], spot_id: @spot.id)
+        if @planned_spot.new_record?
+          @planned_spot.user_id = current_user.id
+          @planned_spot.save
+          format.turbo_stream { flash.now[:notice] = "スポットを登録しました" }
+        end
+        format.turbo_stream { flash.now[:alert] = "そのスポットはすでにプランに登録されています" }
       end
     end
   end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -9,7 +9,7 @@ class SpotsController < ApplicationController
           flash.now[:alert] = 'スポット名を入力してください'
           render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")
         end
-      when (@spot = Spot.save_spot(spot_params)) == false
+      when (@spot = Spot.save_spot(spot_params[:name])) == false
         format.turbo_stream do
           flash.now[:alert] = 'スポットが見つかりませんでした'
           render turbo_stream: turbo_stream.prepend("flash", partial: "shared/flash_message")

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -30,18 +30,12 @@ class Plan < ApplicationRecord
   private
 
   def dates_check
-    if start_date.present? && end_date.present?
-      if start_date > end_date
-        errors.add(:start_date, '旅行終了日より前の日付に設定してください')
-        return # ここで返却、以下の処理をスキップする。
-      end
-    end
-
-    if start_date.present? && start_date < Date.today
+    case
+    when start_date.present? && end_date.present? && start_date > end_date
+      errors.add(:start_date, '旅行終了日より前の日付に設定してください')
+    when start_date.present? && start_date < Date.today
       errors.add(:start_date, '今日以降の日付に設定してください')
-    end
-
-    if end_date.present? && end_date < Date.today
+    when end_date.present? && end_date < Date.today
       errors.add(:end_date, '今日以降の日付に設定してください')
     end
   end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -19,6 +19,9 @@ class Spot < ApplicationRecord
 
   def self.save_spot(location_name)
     results = Geocoder.search(location_name)
+
+    return false if results.empty? # resutlsが空ならfalseを返す
+
     spot = find_or_initialize_by(place_id: results.first.place_id)
 
     if spot.new_record?

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -54,7 +54,8 @@
         if (status === 'OK') {
           console.log(result.routes[0]);
           result.routes[0].legs[0].start_address = '出発地：<%= j render 'spots/modal', spot: @start_location %>';
-          result.routes[0].legs[6].end_address = '到着地：<%= j render 'spots/modal', spot: @end_location %>';
+          // 配列の一番最後を取得
+          result.routes[0].legs[result.routes[0].legs.length - 1].end_address = '到着地：<%= j render 'spots/modal', spot: @end_location %>';
 
           <% @ranking_spots.each_with_index do |spot, index| %>
             result.routes[0].legs[<%= index + 1 %>].start_address = '<%= j render 'spots/modal', spot: spot %>';
@@ -97,8 +98,6 @@
         location.reload(); // リストを更新するため、ページを再読み込み
         sessionStorage.removeItem('first_load'); // 最初のロード情報を削除
       };
-
-
     } else {
       searchRoute(initialWayPoints, false); // 最適化を無効
     }

--- a/app/views/plans/_list_ranking.html.erb
+++ b/app/views/plans/_list_ranking.html.erb
@@ -21,23 +21,23 @@
       <div class="overflow-auto h-[400px] w-[300px] md:w-[1300px] mx-auto">
         <table class="table table-sm md:table-md table-pin-rows table-pin-cols">
           <% if ranking_spots.present? %>
-          <thead>
-            <tr>
-              <th class="md:w-[100px]"></th>
-              <th>スポット名</th>
-              <th class="md:w-[100px]">登録者</th>
-              <th class="md:w-[100px]">みんなの行きたい度</th>
-              <th class="md:w-[100px]"></th>
-            </tr>
-          </thead>
-          <tbody id="ranking-table">
-            <% ranking_spots.each_with_index do |spot, index| %>
-              <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
-              <% spot_subscribers[spot.id].each do |user| %>
-                <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'ranking' } %>
+            <thead>
+              <tr>
+                <th class="md:w-[100px]"></th>
+                <th>スポット名</th>
+                <th class="md:w-[100px]">登録者</th>
+                <th class="md:w-[100px]">みんなの行きたい度</th>
+                <th class="md:w-[100px]"></th>
+              </tr>
+            </thead>
+            <tbody id="ranking-table">
+              <% ranking_spots.each_with_index do |spot, index| %>
+                <% spot_point = spot_points.find { |spot_id, spot_point| spot_id == spot.id }&.last %>
+                <% spot_subscribers[spot.id].each do |user| %>
+                  <%= render partial: 'spots/spot_rankig', locals: { spot: spot, plan: plan, user: user, spot_point: spot_point, spot_counter: spot_counter, index: index, tab_type: 'ranking' } %>
+                <% end %>
               <% end %>
-            <% end %>
-          </tbody>
+            </tbody>
           <% else %>
             <p class="whitespace-nowrap text-sm md:text-lg md:text-center p-4 md:p-10">
               右上の


### PR DESCRIPTION
### 概要
コントローラーの条件分岐をリファクタリング

### 内容
- [x] 複数回記載していたコードはモデルメソッドとして切り出し
- [x] コントローラーが助長になってしまうコードはプライベートメソッドとして切り出し
- [x] if文がネストしている部分はcaseに置き換え

### 補足
 ルート詳細ページで到着地の情報ウィンドウを代入する配列が６になっており、６以下の場合にエラーが出てしまったので、修正。
