### PR TITLE
【feature】ユーザーのモデルスペックを作成 close #272

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :user do
-    
+    email { "example.example.com" }
+    password { "12345678" }
+    password_confirmation { "12345678" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name { 'user' }
-    email { 'example.example.com' }
+    email { 'example@example.com' }
     password { '12345678' }
     password_confirmation { '12345678' }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :user do
-    email { "example.example.com" }
-    password { "12345678" }
-    password_confirmation { "12345678" }
+    name { 'user' }
+    email { 'example.example.com' }
+    password { '12345678' }
+    password_confirmation { '12345678' }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,18 @@ RSpec.describe User, type: :model do
     expect(user).to be_valid
   end
 
-  it 'メールはユニークであること' do
+  it '名前、メールアドレス、パスワードが空欄であれば無効であること' do
+    user = build(:user)
+    user.name = nil
+    user.email = nil
+    user.password = nil
+    user.valid?
+    expect(user.errors[:name]).to include('を入力してください')
+    expect(user.errors[:email]).to include('を入力してください')
+    expect(user.errors[:password]).to include('を入力してください')
+  end
+
+  it 'メールアドレスはユニークであること' do
     user1 = create(:user)
     user2 = build(:user)
     user2.email = user1.email
@@ -14,4 +25,18 @@ RSpec.describe User, type: :model do
     expect(user2.errors[:email]).to include('はすでに存在します')
   end
 
+  it '名前は2文字以上であること' do
+    user = build(:user)
+    user.name = 'a'
+    user.valid?
+    expect(user.errors[:name]).to include('は2文字以上で入力してください')
+  end
+
+  it 'パスワードは6文字以上であること' do
+    user = build(:user)
+    user.password = '12345'
+    user.password_confirmation = '12345'
+    user.valid?
+    expect(user.errors[:password]).to include('は6文字以上で入力してください')
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  it '名前、メールアドレスがあり、パスワードは6文字以上であれば有効であること' do
+    user = build(:user)
+    expect(user).to be_valid
+  end
+
+  it 'メールはユニークであること' do
+    user1 = create(:user)
+    user2 = build(:user)
+    user2.email = user1.email
+    user2.valid?
+    expect(user2.errors[:email]).to include('はすでに存在します')
+  end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end


### PR DESCRIPTION
### 概要
ユーザーのモデルスペックを作成

### 実際のテスト結果
<img width="671" alt="a02abe2c951e714621af5b8a518fe76d" src="https://github.com/maru973/Tripot_Share/assets/148407473/294bde50-5fe6-4d49-8ffa-a72a6ecdb3bc">

### 内容
- [x] 名前、メアド、パスワードが入力されていれば、エラーにならないこと
- [x] 名前、メアド、パスワードが空欄ならエラーになること
- [x] メアドがすでに存在していればエラーになること
- [x] 名前が2文字以下の場合はエラーになること
- [x] パスワードが6文字以下の場合はエラーになること