### PR TITLE
【feature】プランモデルスペックの作成 close #274

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -32,11 +32,11 @@ class Plan < ApplicationRecord
   def dates_check
     case
     when start_date.present? && end_date.present? && start_date > end_date
-      errors.add(:start_date, '旅行終了日より前の日付に設定してください')
+      errors.add(:start_date, 'は旅行終了日より前の日付に設定してください')
     when start_date.present? && start_date < Date.today
-      errors.add(:start_date, '今日以降の日付に設定してください')
+      errors.add(:start_date, 'は今日以降の日付に設定してください')
     when end_date.present? && end_date < Date.today
-      errors.add(:end_date, '今日以降の日付に設定してください')
+      errors.add(:end_date, 'は今日以降の日付に設定してください')
     end
   end
 

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :plan do
+    sequence(:name) { |n| "プラン#{n}" }
+    start_date { Date.tomorrow }
+    end_date { Date.tomorrow + 7.days }
+    location { '京都府' }
+    association :owner, factory: :user
+  end
+end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Plan, type: :model do
-  context ''
+  it '全フィールドが入力されている場合有効になること' do
+    plan = build(:plan)
+    expect(plan).to be_valid
+  end
+
+  it 'プラン名が空欄の場合は無効になること' do
+    plan = build(:plan)
+    plan.name = nil
+    plan.valid?
+    expect(plan.errors[:name]).to include('を入力してください')
+  end
+
+  it '行き先が空欄の場合は無効になること' do
+    plan = build(:plan)
+    plan.location = nil
+    plan.valid?
+    expect(plan.errors[:location]).to include('を入力してください')
+  end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -19,4 +19,26 @@ RSpec.describe Plan, type: :model do
     plan.valid?
     expect(plan.errors[:location]).to include('を入力してください')
   end
+
+  it '出発日が到着日より後の日付の場合無効になること' do
+    plan = build(:plan)
+    plan.start_date = Date.tomorrow + 8.days
+    plan.valid?
+    expect(plan.errors[:start_date]).to include('は旅行終了日より前の日付に設定してください')
+  end
+
+  it '出発日が今日以前の場合無効になること' do
+    plan = build(:plan)
+    plan.start_date = Date.yesterday
+    plan.valid?
+    expect(plan.errors[:start_date]).to include('は今日以降の日付に設定してください')
+  end
+
+  it '到着日今日以前の場合無効になること' do
+    plan = build(:plan)
+    plan.start_date = nil
+    plan.end_date = Date.yesterday
+    plan.valid?
+    expect(plan.errors[:end_date]).to include('は今日以降の日付に設定してください')
+  end 
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Plan, type: :model do
+  context ''
+end


### PR DESCRIPTION
### 概要
プランモデルスペックの作成

### テスト結果
<img width="620" alt="377d98542c9751ca7058ea8bdbe20416" src="https://github.com/maru973/Tripot_Share/assets/148407473/a7d41011-6c8d-4af6-8ce5-09cc5414b3c5">


### 内容
- [x] .rspecに--format documentationを追加してテストコードの条件文が表示される
- [x] プラン名、行き先が登録されていればエラーにならないこと
- [x] プラン名が空欄の場合はエラーになること
- [x] 行き先が空欄の場合はエラーになること
- [x] 出発日が到着日より後の日付の場合はエラーになること
- [x] 出発日が今日以前の場合はエラーになること
- [x] 到着日が今日以前の場合はエラーになること

### 補足
エラー文を一部修正。