### PR TITLE
【feature】コースモデルスペックの作成 close #273

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :course do
+    
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :course do
-    
+    start_location { '京都駅' }
+    end_location { '大宮駅' }
+    association :plan
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it '全フィールドが入力されている場合有効になること' do
+    course = build(:course)
+    expect(course).to be_valid
+  end
+
+  it '全フィールドが空欄の場合無効になること' do
+    course = build(:course)
+    course.start_location = nil
+    course.end_location = nil
+    expect(course).to be_invalid
+  end
+
+  it '出発地が空欄の場合無効になること' do
+    course = build(:course)
+    course.start_location = nil
+    expect(course).to be_invalid
+  end
+
+  it '到着地が空欄の場合無効になること' do
+    course = build(:course)
+    course.end_location = nil
+    expect(course).to be_invalid
+  end
 end


### PR DESCRIPTION
### 概要
コースモデルスペックの作成

### テスト結果
<img width="662" alt="8887e718e76980ec5c113d9513d779fe" src="https://github.com/maru973/Tripot_Share/assets/148407473/3c77f582-dff9-412d-b9d6-6ea40eaca9f9">

### 内容
- [x] 出発地、到着地が空欄の場合エラーになること
- [x] 出発地のみ空欄の場合エラーになること
- [x] 到着地のみ空欄の場合エラーになること
- [x] 出発地、到着地が入力されていればエラーにならないこと