### PR TITLE
【feature】ユーザー新規登録のシステムスペック作成 close #278

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,11 @@ group :development do
   gem 'letter_opener_web'
 end
 
+group :test do
+  gem 'capybara'
+  gem 'selenium-webdriver'
+end
+
 gem 'cssbundling-rails'
 gem 'jsbundling-rails'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,15 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     carrierwave (3.0.7)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -198,6 +207,7 @@ GEM
       letter_opener (~> 1.7)
       railties (>= 5.2)
       rexml
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -207,6 +217,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.2)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0507)
@@ -315,6 +326,7 @@ GEM
       i18n
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
+    regexp_parser (2.9.2)
     reline (0.5.1)
       io-console (~> 0.5)
     responders (3.1.1)
@@ -340,6 +352,13 @@ GEM
     rspec-support (3.13.1)
     ruby-vips (2.2.1)
       ffi (~> 1.12)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.22.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -372,9 +391,12 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     webrick (1.8.1)
+    websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.13)
 
 PLATFORMS
@@ -384,6 +406,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  capybara
   carrierwave
   cssbundling-rails
   debug
@@ -409,6 +432,7 @@ DEPENDENCIES
   ranked-model
   ransack
   rspec-rails
+  selenium-webdriver
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
 
+  it 'ユーザーが新規登録できること' do
+    visit '/users/sign_up'
+    expect { 
+      fill_in '名前', with: 'テスト'
+      fill_in 'メールアドレス', with: 'example@example.com'
+      fill_in 'パスワード', with: '12345678'
+      fill_in 'パスワード（確認用）', with: '12345678'
+      click_button 'アカウント登録'
+      Capybara.assert_current_path("/plans", ignore_query: true)
+    }.to change { User.count }.by(1)
+    expect(page).to have_content('アカウント登録が完了しました'), 'フラッシュメッセージ「アカウント登録が完了しました」が表示されていません'
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -17,4 +17,30 @@ RSpec.describe "Users", type: :system do
     }.to change { User.count }.by(1)
     expect(page).to have_content('アカウント登録が完了しました'), 'フラッシュメッセージ「アカウント登録が完了しました」が表示されていません'
   end
+
+  context 'ユーザーの新規新規登録できない' do
+    it '空欄箇所がある場合' do
+      visit '/users/sign_up'
+      expect { 
+        fill_in '名前', with: 'テスト'
+        click_button 'アカウント登録'
+      }.to change { User.count }.by(0)
+      expect(page).to have_content('メールアドレスを入力してください'), 'エラーメッセージ「メールアドレスを入力してください」が表示されていません'
+      expect(page).to have_content('パスワードを入力してください'), 'エラーメッセージ「パスワードを入力してください」が表示されていません'
+    end
+
+    it 'すでに登録済みの場合' do
+      create(:user)
+      visit '/users/sign_up'
+      expect { 
+        fill_in '名前', with: 'テスト'
+        fill_in 'メールアドレス', with: 'example@example.com'
+        fill_in 'パスワード', with: '12345678'
+        fill_in 'パスワード（確認用）', with: '12345678'
+        click_button 'アカウント登録'
+      }.to change { User.count }.by(0)
+      expect(page).to have_content('メールアドレスはすでに存在します'), 'エラーメッセージ「メールアドレスはすでに存在します」が表示されていません'
+    end
+  end
+
 end


### PR DESCRIPTION
### 概要
ユーザー新規登録のシステムスペック作成

### テスト結果
<img width="637" alt="d8d5356825f61f2911fe4ad42d0ce084" src="https://github.com/maru973/Tripot_Share/assets/148407473/7716f538-afde-4c50-a41c-06568d51c2f3">


### 内容
- [x] capybaraとselenium-webdriverのインストール
- [x] 新規登録ができた場合、`/plans`に遷移し登録完了のフラッシュメッセージが表示されること
- [x] 新規登録ができなかった場合、バリデーションエラーが表示されること
- [x] すでにメールアドレスが存在する場合、エラーになること 