### PR TITLE
【feature】プランのシステムスペック作成 close #280

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,5 +63,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
-  config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,5 +63,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
-  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe "Plans", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+end

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -5,9 +5,26 @@ RSpec.describe "Plans", type: :system do
     driven_by(:rack_test)
   end
 
+  let(:user) { create(:user) }
+
   describe 'プラン作成' do
     context 'ログイン済み' do
+      before do
+        login_as(user)
+        visit '/plans'
+        click_link '旅行プランをつくる'
+      end
+
       it 'プランが作成されスポット登録ページに遷移すること' do
+        expect { 
+          fill_in 'プラン名', with: 'プラン１'
+          find("option[value='京都府']").select_option
+          click_button '作成'
+        }.to change { Plan.count }.by(1)
+        plan = Plan.last
+        Capybara.assert_current_path("/plans/#{plan.id}/new_spots", ignore_query: true)
+        expect(page).to have_content("#{plan.name}を作成しました"), 'フラッシュメッセージ「#{プラン名}を作成しました」が表示されていません'
+        expect(page).to have_content('スポット登録'), '「スポット登録」の文言が表示されていません'
       end
 
       it 'プラン作成ができないこと' do

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe "Plans", type: :system do
       end
 
       it 'プラン作成ができないこと' do
+        expect { 
+          fill_in 'プラン名', with: 'プラン１'
+          click_button '作成'
+        }.to change { Plan.count }.by(0)
+        expect(page).to have_content('プランを作成出来ませんでした'), 'フラッシュメッセージ「プランを作成出来ませんでした」が表示されていません'
+        expect(page).to have_content('旅行先の都道府県名を入力してください'), 'エラーメッセージ「旅行先の都道府県名を入力してください」が表示されていません'
       end
     end
 

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Plans", type: :system do
         }.to change { Plan.count }.by(1)
         plan = Plan.last
         Capybara.assert_current_path("/plans/#{plan.id}/new_spots", ignore_query: true)
+        expect(current_path).to eq("/plans/#{plan.id}/new_spots"), 'プラン新規作成に成功した時、スポット登録ページにリダイレクトされていません'
         expect(page).to have_content("#{plan.name}を作成しました"), 'フラッシュメッセージ「#{プラン名}を作成しました」が表示されていません'
         expect(page).to have_content('スポット登録'), '「スポット登録」の文言が表示されていません'
       end
@@ -39,6 +40,10 @@ RSpec.describe "Plans", type: :system do
 
     context '未ログイン' do
       it 'ログインページにリダイレクトされること' do
+        visit '/plans/new'
+        Capybara.assert_current_path('/users/sign_in', ignore_query: true)
+        expect(current_path).to eq('/users/sign_in'), '未ログイン時に、プラン新規作成画面にアクセスした際に、ログインページにリダイレクトされていません'
+        expect(page).to have_content('ログインもしくはアカウント登録してください'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください」が表示されていません'
       end
     end
   end

--- a/spec/system/plans_spec.rb
+++ b/spec/system/plans_spec.rb
@@ -5,4 +5,18 @@ RSpec.describe "Plans", type: :system do
     driven_by(:rack_test)
   end
 
+  describe 'プラン作成' do
+    context 'ログイン済み' do
+      it 'プランが作成されスポット登録ページに遷移すること' do
+      end
+
+      it 'プラン作成ができないこと' do
+      end
+    end
+
+    context '未ログイン' do
+      it 'ログインページにリダイレクトされること' do
+      end
+    end
+  end
 end


### PR DESCRIPTION
### 概要
プランのシステムスペック作成

### テスト結果
<img width="609" alt="2000fd26092bfb557d088ee107f6f429" src="https://github.com/user-attachments/assets/22c3855e-3292-4d99-b900-2c6651d2ff2c">


### 内容
**ログインしている場合**
- [x] ヘッダーのリンクから`/plans/new`へ遷移できること
- [x] プランが作成に成功した場合、`/plans/:id/new_spots`に遷移しフラッシュメッセージが表示されること
- [x] プランが作成に失敗した場合、`/plans/new`に戻りフラッシュメッセージが表示されること

**ログインしていない場合**
- [x] `/plans/new`に遷移できず、`/users/sign_in`に遷移し、フラッシュメッセージが表示されること