### PR TITLE
【feature】他のサイトのリンクを追加

### DIFF
--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -14,6 +14,8 @@
         <div class="form-control my-3">
           <%= f.label :location %>
           <%= f.select :location, options_for_select(Plan::JAPAN_PREFECTURES), {include_blank: ""}, {class: "select select-sm md:select-md select-bordered"} %>
+          <%= link_to "みんなのおすすめ旅を参考にして旅先決める？", "https://tabi-tsunagi.com/", target: :_blank, class: "text-xs md:text-sm link link-primary text-center" %>
+          <p class="text-xs md:text-sm text-center">(外部サイトに移動します)</p>
         </div>
 
         <div class="form-control my-3">


### PR DESCRIPTION
### 概要
他のサイトのリンクを追加

### 実装ページ
<img width="500" alt="c375f43cac97c3d64df18f6e3dc79aa6" src="https://github.com/user-attachments/assets/0c163c22-e515-480f-babc-d185040fc83a">

### 内容
- [x] 他の受講生のサービスに遷移できるように実装


### 補足
他の受講生からの案で似たコンセプトのサービスにも飛べるようにした。